### PR TITLE
Add missing dependencies and fix test command #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+debug.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright Contributors to the ODPi Egeria project.
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 5. [Release cycle](#release-cycle)
 6. [Using egeria-ui as a dependency](#using-egeria-ui-as-a-dependency)
 7. [Links](#links)
+8. [License](#license)
 
 ## Prerequisites
 |         |   Version  |
@@ -86,7 +87,7 @@ Build the egeria project [2] and deploy it with all the required ENV variables, 
 
 
 ## Release cycle
-Egeria-UI use GitHub as its dependency provider, this means that all the releases are being pushed to the Github Egeria-UI repository here [1]. 
+Egeria-UI use GitHub as its dependency provider, this means that all the releases are being pushed to the Github Egeria-UI repository here [1].
 
 ```bash
 $ git clone https://github.com/odpi/egeria-ui     # clone and checkout to master branch
@@ -119,3 +120,8 @@ You can also use a branch name or commit ID to point to a version, useful for wo
 [1] - https://github.com/odpi/egeria-ui/releases
 
 [2] - https://github.com/odpi/egeria
+
+
+## License
+SPDX-License-Identifier: Apache-2.0
+Copyright Contributors to the ODPi Egeria project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -575,6 +575,18 @@
         "@webcomponents/shadycss": "^1.9.1"
       }
     },
+    "@polymer/sinonjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+      "integrity": "sha512-/U8F/cOTrbF2iVVYgINYmvKbtbexs+89Q3v8AaHADRYabTg7aOZGOb0RyWpOI+sUJt04kj63U4FwMhzW5r4wZA==",
+      "dev": true
+    },
+    "@polymer/test-fixture": {
+      "version": "3.0.0-pre.21",
+      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
+      "integrity": "sha512-IxzUe6YzaORzUksafHAXHprV29YncOJgr0+1zNAifl0/f+cb5iAd4IWUrnsnVFHG5UGTLjvis5RgV6vvIZPDrA==",
+      "dev": true
+    },
     "@vaadin/router": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.7.2.tgz",
@@ -1379,25 +1391,395 @@
       "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz",
       "integrity": "sha512-UWXZYbaDLLfhm+xONXTiDciyhOSwKRrZieGQHFMSMGSxY4mbjZ5uYzOKgnuX0luYFvjJw32G3r0sCwQZPJIR4Q=="
     },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
     "cookieconsent": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/cookieconsent/-/cookieconsent-3.1.1.tgz",
       "integrity": "sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag=="
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "ecstatic": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
+      "dev": true,
+      "requires": {
+        "he": "^1.1.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.1.0",
+        "url-join": "^2.0.5"
+      }
     },
     "emitter-component": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
       "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
+    "es-abstract": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
     "hammerjs": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
       "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "highcharts": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-8.1.2.tgz",
       "integrity": "sha512-Q124Lj+2+bVY2MKMd7d8uSVAmhZVzWgknUUzUBEC27S94dCyK6PBgahuwiMP/ET4w7qSFBBi4OC77ZUb0Vnuyg=="
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-server": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.3.tgz",
+      "integrity": "sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^1.0.3",
+        "colors": "^1.4.0",
+        "corser": "^2.0.1",
+        "ecstatic": "^3.3.2",
+        "http-proxy": "^1.18.0",
+        "minimist": "^1.2.5",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.25",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "intl-messageformat": {
       "version": "2.2.0",
@@ -1411,6 +1793,72 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
       "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "dev": true
+    },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
     },
     "keycharm": {
       "version": "0.2.0",
@@ -1430,10 +1878,184 @@
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
       "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "moment": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
       "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "multiselect-combo-box": {
       "version": "2.4.2",
@@ -1449,10 +2071,14148 @@
         "@vaadin/vaadin-themable-mixin": "^1.4.4"
       }
     },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
       "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
+    },
+    "polymer-cli": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/polymer-cli/-/polymer-cli-1.9.11.tgz",
+      "integrity": "sha512-tiURjHDCOUUtDVPuVYvrfFI9PXe4OOUmBbn6Sg5GJNQ2POtP7r7hv+I5yI8P9qsxmalHTa19chVtf5/t9IBXDg==",
+      "dev": true,
+      "requires": {
+        "@octokit/rest": "^16.2.0",
+        "@types/chalk": "^2.2.0",
+        "@types/del": "^3.0.0",
+        "@types/findup-sync": "^0.3.29",
+        "@types/globby": "^6.1.0",
+        "@types/inquirer": "0.0.32",
+        "@types/merge-stream": "^1.0.28",
+        "@types/mz": "^0.0.31",
+        "@types/request": "2.0.3",
+        "@types/resolve": "0.0.4",
+        "@types/rimraf": "^0.0.28",
+        "@types/semver": "^5.3.30",
+        "@types/temp": "^0.8.28",
+        "@types/update-notifier": "^1.0.0",
+        "@types/vinyl": "^2.0.0",
+        "@types/vinyl-fs": "0.0.28",
+        "@types/yeoman-generator": "^2.0.3",
+        "bower": "^1.8.8",
+        "bower-json": "^0.8.1",
+        "bower-logger": "^0.2.2",
+        "chalk": "^2.4.2",
+        "chokidar": "^1.7.0",
+        "command-line-args": "^5.0.2",
+        "command-line-commands": "^2.0.1",
+        "command-line-usage": "^5.0.5",
+        "del": "^3.0.0",
+        "findup-sync": "^0.4.2",
+        "globby": "^8.0.1",
+        "gunzip-maybe": "^1.3.1",
+        "inquirer": "^1.0.2",
+        "merge-stream": "^1.0.1",
+        "mz": "^2.6.0",
+        "plylog": "^1.0.0",
+        "polymer-analyzer": "^3.2.2",
+        "polymer-build": "^3.1.4",
+        "polymer-bundler": "^4.0.9",
+        "polymer-linter": "^3.0.0",
+        "polymer-project-config": "^4.0.3",
+        "polyserve": "^0.27.15",
+        "request": "^2.72.0",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar-fs": "^1.12.0",
+        "temp": "^0.8.3",
+        "update-notifier": "^1.0.0",
+        "validate-element-name": "^2.1.1",
+        "vinyl": "^1.1.1",
+        "vinyl-fs": "^2.4.3",
+        "web-component-tester": "^6.9.0",
+        "yeoman-environment": "^1.5.2",
+        "yeoman-generator": "^3.1.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/core": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.4.tgz",
+          "integrity": "sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.5.0",
+            "@babel/helpers": "^7.5.4",
+            "@babel/parser": "^7.5.0",
+            "@babel/template": "^7.4.4",
+            "@babel/traverse": "^7.5.0",
+            "@babel/types": "^7.5.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.11",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
+          "integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.5.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+          "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+          "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-explode-assignable-expression": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-call-delegate": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+          "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.4.4",
+            "@babel/traverse": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+          "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/types": "^7.4.4",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/helper-explode-assignable-expression": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+          "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+          "dev": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+          "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+          "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+          "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+          "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/template": "^7.4.4",
+            "@babel/types": "^7.4.4",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+          "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+          "dev": true
+        },
+        "@babel/helper-regex": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+          "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+          "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-wrap-function": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+          "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+          "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+          "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.2.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.4.tgz",
+          "integrity": "sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.4.4",
+            "@babel/traverse": "^7.5.0",
+            "@babel/types": "^7.5.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+          "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
+          "integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
+          "dev": true
+        },
+        "@babel/plugin-external-helpers": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.2.0.tgz",
+          "integrity": "sha512-QFmtcCShFkyAsNtdCM3lJPmRe1iB+vPZymlB4LnDIKEBj2yKQLQKtoxXxJ8ePT5fwMl4QGg303p4mB0UsSI2/g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+          "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0",
+            "@babel/plugin-syntax-async-generators": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.4.tgz",
+          "integrity": "sha512-KCx0z3y7y8ipZUMAEEJOyNi11lMb/FOPUjjB113tfowgw0c16EGYos7worCKBcUAh2oG+OBnoUhsnTSoLpV9uA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+          }
+        },
+        "@babel/plugin-syntax-async-generators": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+          "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+          "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-import-meta": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.2.0.tgz",
+          "integrity": "sha512-Hq6kFSZD7+PHkmBN8bCpHR6J8QEoCuEV/B38AIQscYjgMZkGlXB7cHNFzP5jR4RCh5545yP1ujHdmO7hAgKtBA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+          "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+          "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+          "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+          "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+          "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+          "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-define-map": "^7.4.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.4.4",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-computed-properties": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+          "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+          "integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+          "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+          "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+          "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+          "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-instanceof": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.2.0.tgz",
+          "integrity": "sha512-tw2fb96tpcd5XaJXns19tGKo/SeIUS0exAteHJ/7EP27Bke7RmV/gAftHCf1WKZgKeZOUfzOL7nrXH2HIH9auA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-literals": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+          "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+          "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+          "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+          "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-call-delegate": "^7.4.4",
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+          "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+          "dev": true,
+          "requires": {
+            "regenerator-transform": "^0.14.0"
+          }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+          "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+          "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+          "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+          "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+          "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+          "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.4.4",
+            "regexpu-core": "^4.5.4"
+          }
+        },
+        "@babel/template": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+          "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.0.tgz",
+          "integrity": "sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.5.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.5.0",
+            "@babel/types": "^7.5.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
+          "integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "@mrmlnc/readdir-enhanced": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+          "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "glob-to-regexp": "^0.3.0"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+        },
+        "@octokit/endpoint": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.2.1.tgz",
+          "integrity": "sha512-GoUsRSRhtbCQugRY8eDWg5BnsczUZNq00qArrP7tKPHFmvz2KzJ8DoEq6IAQhLGwAOBHbZQ/Zml3DiaEKAWwkA==",
+          "dev": true,
+          "requires": {
+            "deepmerge": "4.0.0",
+            "is-plain-object": "^3.0.0",
+            "universal-user-agent": "^2.1.0",
+            "url-template": "^2.0.8"
+          }
+        },
+        "@octokit/request": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-4.1.1.tgz",
+          "integrity": "sha512-LOyL0i3oxRo418EXRSJNk/3Q4I0/NKawTn6H/CQp+wnrG1UFLGu080gSsgnWobhPo5BpUNgSQ5BRk5FOOJhD1Q==",
+          "dev": true,
+          "requires": {
+            "@octokit/endpoint": "^5.1.0",
+            "@octokit/request-error": "^1.0.1",
+            "deprecation": "^2.0.0",
+            "is-plain-object": "^3.0.0",
+            "node-fetch": "^2.3.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^2.1.0"
+          }
+        },
+        "@octokit/request-error": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
+          "integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+          "dev": true,
+          "requires": {
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/rest": {
+          "version": "16.28.2",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.2.tgz",
+          "integrity": "sha512-csuYiHvJ1P/GFDadVn0QhwO83R1+YREjcwCY7ZIezB6aJTRIEidJZj+R7gAkUhT687cqYb4cXTZsDVu9F+Fmug==",
+          "dev": true,
+          "requires": {
+            "@octokit/request": "^4.0.1",
+            "@octokit/request-error": "^1.0.2",
+            "atob-lite": "^2.0.0",
+            "before-after-hook": "^1.4.0",
+            "btoa-lite": "^1.0.0",
+            "deprecation": "^2.0.0",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "lodash.uniq": "^4.5.0",
+            "octokit-pagination-methods": "^1.1.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^2.0.0",
+            "url-template": "^2.0.8"
+          }
+        },
+        "@polymer/esm-amd-loader": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
+          "integrity": "sha512-h+hqYkL+tQV/y2ESD5gFXMl5z4cC+XY1jTlBeGSBaTcj3VbB5OBEScbvRXm63NcEbBneQQYbHfBAXAkF9i9wIA==",
+          "dev": true
+        },
+        "@polymer/sinonjs": {
+          "version": "1.17.1",
+          "resolved": "https://registry.npmjs.org/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+          "integrity": "sha512-/U8F/cOTrbF2iVVYgINYmvKbtbexs+89Q3v8AaHADRYabTg7aOZGOb0RyWpOI+sUJt04kj63U4FwMhzW5r4wZA==",
+          "dev": true
+        },
+        "@polymer/test-fixture": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+          "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
+          "dev": true
+        },
+        "@polymer/tools-common": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/tools-common/-/tools-common-2.0.1.tgz",
+          "integrity": "sha512-McFmpKINBpdDkIz7jf+hIddUDYLaeEV+SFqfoNJEYZwgXZta145fy/SlXSKj31RcAjroxfocRplN/p3HLYwloQ==",
+          "requires": {
+            "@types/node": "^9.6.4",
+            "depcheck": "^0.6.0",
+            "fs-extra": "^3.0.0",
+            "gulp-eslint": "^4.0.0",
+            "gulp-mocha": "^6.0.0",
+            "gulp-tslint": "^8.0.0",
+            "gulp-typescript": "^3.0.0",
+            "merge-stream": "^1.0.0",
+            "run-sequence": "^1.0.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "9.6.49",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.49.tgz",
+              "integrity": "sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA=="
+            },
+            "fs-extra": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+              "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^3.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "@sinonjs/commons": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+          "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/formatio": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+          "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+          "requires": {
+            "samsam": "1.3.0"
+          }
+        },
+        "@sinonjs/samsam": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+          "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+          "requires": {
+            "@sinonjs/commons": "^1.0.2",
+            "array-from": "^2.1.1",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@sinonjs/text-encoding": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+          "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+        },
+        "@types/babel-generator": {
+          "version": "6.25.3",
+          "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.3.tgz",
+          "integrity": "sha512-pGgnuxVddKcYIc+VJkRDop7gxLhqclNKBdlsm/5Vp8d+37pQkkDK7fef8d9YYImRzw9xcojEPc18pUYnbxmjqA==",
+          "dev": true,
+          "requires": {
+            "@types/babel-types": "*"
+          }
+        },
+        "@types/babel-traverse": {
+          "version": "6.25.5",
+          "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
+          "integrity": "sha512-WrMbwmu+MWf8FiUMbmVOGkc7bHPzndUafn1CivMaBHthBBoo0VNIcYk1KV71UovYguhsNOwf3UF5oRmkkGOU3w==",
+          "dev": true,
+          "requires": {
+            "@types/babel-types": "*"
+          }
+        },
+        "@types/babel-types": {
+          "version": "6.25.2",
+          "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
+          "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==",
+          "dev": true
+        },
+        "@types/babylon": {
+          "version": "6.16.5",
+          "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
+          "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
+          "dev": true,
+          "requires": {
+            "@types/babel-types": "*"
+          }
+        },
+        "@types/bluebird": {
+          "version": "3.5.27",
+          "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.27.tgz",
+          "integrity": "sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==",
+          "dev": true
+        },
+        "@types/body-parser": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+          "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+          "dev": true,
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/chai": {
+          "version": "4.1.7",
+          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+          "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+          "dev": true
+        },
+        "@types/chai-subset": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.2.tgz",
+          "integrity": "sha512-VMA1aOXwPEJADlj5ykmYv77YKmbEuAxiLz/+lT6vFIWQ1EA06jF01TytVBAbVTNk0pjfW1Uhw5R5MaEq426N0A==",
+          "dev": true,
+          "requires": {
+            "@types/chai": "*"
+          }
+        },
+        "@types/chalk": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
+          "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
+          "dev": true,
+          "requires": {
+            "chalk": "*"
+          }
+        },
+        "@types/chokidar": {
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-1.7.5.tgz",
+          "integrity": "sha512-PDkSRY7KltW3M60hSBlerxI8SFPXsO3AL/aRVsO4Kh9IHRW74Ih75gUuTd/aE4LSSFqypb10UIX3QzOJwBQMGQ==",
+          "requires": {
+            "@types/events": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/clean-css": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.1.tgz",
+          "integrity": "sha512-A1HQhQ0hkvqqByJMgg+Wiv9p9XdoYEzuwm11SVo1mX2/4PSdhjcrUlilJQoqLscIheC51t1D5g+EFWCXZ2VTQQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/clone": {
+          "version": "0.1.30",
+          "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+          "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
+          "dev": true
+        },
+        "@types/compression": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
+          "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
+          "dev": true,
+          "requires": {
+            "@types/express": "*"
+          }
+        },
+        "@types/connect": {
+          "version": "3.4.32",
+          "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+          "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/content-type": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@types/content-type/-/content-type-1.1.3.tgz",
+          "integrity": "sha512-pv8VcFrZ3fN93L4rTNIbbUzdkzjEyVMp5mPVjsFfOYTDOZMZiZ8P1dhu+kEv3faYyKzZgLlSvnyQNFg+p/v5ug==",
+          "dev": true
+        },
+        "@types/cssbeautify": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+          "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8=",
+          "dev": true
+        },
+        "@types/del": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@types/del/-/del-3.0.1.tgz",
+          "integrity": "sha512-y6qRq6raBuu965clKgx6FHuiPu3oHdtmzMPXi8Uahsjdq1L6DL5fS/aY5/s71YwM7k6K1QIWvem5vNwlnNGIkQ==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "*"
+          }
+        },
+        "@types/doctrine": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+          "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0=",
+          "dev": true
+        },
+        "@types/escape-html": {
+          "version": "0.0.20",
+          "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-0.0.20.tgz",
+          "integrity": "sha512-6dhZJLbA7aOwkYB2GDGdIqJ20wmHnkDzaxV9PJXe7O02I2dSFTERzRB6JrX6cWKaS+VqhhY7cQUMCbO5kloFUw==",
+          "dev": true
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "@types/events": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+          "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+        },
+        "@types/express": {
+          "version": "4.17.0",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
+          "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
+          "dev": true,
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "*",
+            "@types/serve-static": "*"
+          }
+        },
+        "@types/express-serve-static-core": {
+          "version": "4.16.7",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+          "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/range-parser": "*"
+          }
+        },
+        "@types/fancy-log": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@types/fancy-log/-/fancy-log-1.3.0.tgz",
+          "integrity": "sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw=="
+        },
+        "@types/fast-levenshtein": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.1.tgz",
+          "integrity": "sha1-OjYVzxc2Rcj8pY0FHk4ygk5L0oY=",
+          "dev": true
+        },
+        "@types/findup-sync": {
+          "version": "0.3.30",
+          "resolved": "https://registry.npmjs.org/@types/findup-sync/-/findup-sync-0.3.30.tgz",
+          "integrity": "sha512-Dpt1x3rhz6t8BMTS4vziTVos8VLkF4RngIxMBCSE6w0STmnVEEaoe3w+BG5xHyZXshye9lyZE99lpBDoLGY8eA==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "*"
+          }
+        },
+        "@types/form-data": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+          "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/freeport": {
+          "version": "1.0.21",
+          "resolved": "https://registry.npmjs.org/@types/freeport/-/freeport-1.0.21.tgz",
+          "integrity": "sha1-c/ZUPtZ9PKP/+XuYVZFZi3CSBm8=",
+          "dev": true,
+          "optional": true
+        },
+        "@types/fs-extra": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+          "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+          "dev": true,
+          "requires": {
+            "@types/events": "*",
+            "@types/minimatch": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/glob-stream": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@types/glob-stream/-/glob-stream-6.1.0.tgz",
+          "integrity": "sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@types/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha512-j3XSDNoK4LO5T+ZviQD6PqfEjm07QFEacOTbJR3hnLWuWX0ZMLJl9oRPgj1PyrfGbXhfHFkksC9QZ9HFltJyrw==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "*"
+          }
+        },
+        "@types/gulp-if": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/@types/gulp-if/-/gulp-if-0.0.33.tgz",
+          "integrity": "sha512-J5lzff21X7r1x/4hSzn02GgIUEyjCqYIXZ9GgGBLhbsD3RiBdqwnkFWgF16/0jO5rcVZ52Zp+6MQMQdvIsWuKg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/vinyl": "*"
+          }
+        },
+        "@types/html-minifier": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+          "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
+          "dev": true,
+          "requires": {
+            "@types/clean-css": "*",
+            "@types/relateurl": "*",
+            "@types/uglify-js": "*"
+          }
+        },
+        "@types/inquirer": {
+          "version": "0.0.32",
+          "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.32.tgz",
+          "integrity": "sha1-pKCOg3QcUAp8PI53dgFPf4plhw0=",
+          "requires": {
+            "@types/rx": "*",
+            "@types/through": "*"
+          }
+        },
+        "@types/is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+          "dev": true
+        },
+        "@types/launchpad": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@types/launchpad/-/launchpad-0.6.0.tgz",
+          "integrity": "sha1-NylhCbfyd/bmxf1+DAcGvJGPu1E=",
+          "dev": true,
+          "optional": true
+        },
+        "@types/merge-stream": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/merge-stream/-/merge-stream-1.1.2.tgz",
+          "integrity": "sha512-7faLmaE99g/yX0Y9pF1neh2IUqOf/fXMOWCVzsXjqI1EJ91lrgXmaBKf6bRWM164lLyiHxHt6t/ZO/cIzq61XA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/mime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+          "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+          "dev": true
+        },
+        "@types/minimatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+          "dev": true
+        },
+        "@types/mz": {
+          "version": "0.0.31",
+          "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.31.tgz",
+          "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/node": {
+          "version": "12.6.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.1.tgz",
+          "integrity": "sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ=="
+        },
+        "@types/opn": {
+          "version": "3.0.28",
+          "resolved": "https://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
+          "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/parse5": {
+          "version": "2.2.34",
+          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
+          "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/path-is-inside": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+          "integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw==",
+          "dev": true
+        },
+        "@types/pem": {
+          "version": "1.9.5",
+          "resolved": "https://registry.npmjs.org/@types/pem/-/pem-1.9.5.tgz",
+          "integrity": "sha512-C0txxEw8B7DCoD85Ko7SEvzUogNd5VDJ5/YBG8XUcacsOGqxr5Oo4g3OUAfdEDUbhXanwUoVh/ZkMFw77FGPQQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/puppeteer": {
+          "version": "1.12.4",
+          "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-1.12.4.tgz",
+          "integrity": "sha512-aaGbJaJ9TuF9vZfTeoh876sBa+rYJWPwtsmHmYr28pGr42ewJnkDTq2aeSKEmS39SqUdkwLj73y/d7rBSp7mDQ==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/range-parser": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+          "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+          "dev": true
+        },
+        "@types/relateurl": {
+          "version": "0.2.28",
+          "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
+          "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
+          "dev": true
+        },
+        "@types/request": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@types/request/-/request-2.0.3.tgz",
+          "integrity": "sha512-cIvnyFRARxwE4OHpCyYue7H+SxaKFPpeleRCHJicft8QhyTNbVYsMwjvEzEPqG06D2LGHZ+sN5lXc8+bTu6D8A==",
+          "dev": true,
+          "requires": {
+            "@types/form-data": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/resolve": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
+          "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/rimraf": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
+          "integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY=",
+          "dev": true
+        },
+        "@types/rx": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
+          "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
+          "requires": {
+            "@types/rx-core": "*",
+            "@types/rx-core-binding": "*",
+            "@types/rx-lite": "*",
+            "@types/rx-lite-aggregates": "*",
+            "@types/rx-lite-async": "*",
+            "@types/rx-lite-backpressure": "*",
+            "@types/rx-lite-coincidence": "*",
+            "@types/rx-lite-experimental": "*",
+            "@types/rx-lite-joinpatterns": "*",
+            "@types/rx-lite-testing": "*",
+            "@types/rx-lite-time": "*",
+            "@types/rx-lite-virtualtime": "*"
+          }
+        },
+        "@types/rx-core": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz",
+          "integrity": "sha1-CzNUsSOM7b4rdPYybxOdvHpZHWA="
+        },
+        "@types/rx-core-binding": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
+          "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
+          "requires": {
+            "@types/rx-core": "*"
+          }
+        },
+        "@types/rx-lite": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.6.tgz",
+          "integrity": "sha512-oYiDrFIcor9zDm0VDUca1UbROiMYBxMLMaM6qzz4ADAfOmA9r1dYEcAFH+2fsPI5BCCjPvV9pWC3X3flbrvs7w==",
+          "requires": {
+            "@types/rx-core": "*",
+            "@types/rx-core-binding": "*"
+          }
+        },
+        "@types/rx-lite-aggregates": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
+          "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-async": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
+          "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-backpressure": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
+          "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-coincidence": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
+          "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-experimental": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
+          "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-joinpatterns": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
+          "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-testing": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
+          "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
+          "requires": {
+            "@types/rx-lite-virtualtime": "*"
+          }
+        },
+        "@types/rx-lite-time": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
+          "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/rx-lite-virtualtime": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
+          "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
+          "requires": {
+            "@types/rx-lite": "*"
+          }
+        },
+        "@types/semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+          "dev": true
+        },
+        "@types/serve-static": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+          "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+          "dev": true,
+          "requires": {
+            "@types/express-serve-static-core": "*",
+            "@types/mime": "*"
+          }
+        },
+        "@types/sinon": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-5.0.7.tgz",
+          "integrity": "sha512-opwMHufhUwkn/UUDk35LDbKJpA2VBsZT8WLU8NjayvRLGPxQkN+8XmfC2Xl35MAscBE8469koLLBjaI3XLEIww=="
+        },
+        "@types/spdy": {
+          "version": "3.4.4",
+          "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
+          "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/temp": {
+          "version": "0.8.34",
+          "resolved": "https://registry.npmjs.org/@types/temp/-/temp-0.8.34.tgz",
+          "integrity": "sha512-oLa9c5LHXgS6UimpEVp08De7QvZ+Dfu5bMQuWyMhf92Z26Q10ubEMOWy9OEfUdzW7Y/sDWVHmUaLFtmnX/2j0w==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/through": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
+          "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0="
+        },
+        "@types/ua-parser-js": {
+          "version": "0.7.33",
+          "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+          "integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
+          "dev": true
+        },
+        "@types/uglify-js": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
+          "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "@types/update-notifier": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-1.0.3.tgz",
+          "integrity": "sha512-BLStNhP2DFF7funARwTcoD6tetRte8NK3Sc59mn7GNALCN975jOlKX3dGvsFxXr/HwQMxxCuRn9IWB3WQ7odHQ==",
+          "dev": true
+        },
+        "@types/uuid": {
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
+          "integrity": "sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/vinyl": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.3.tgz",
+          "integrity": "sha512-hrT6xg16CWSmndZqOTJ6BGIn2abKyTw0B58bI+7ioUoj3Sma6u8ftZ1DTI2yCaJamOVGLOnQWiPH3a74+EaqTA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/vinyl-fs": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-0.0.28.tgz",
+          "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
+          "dev": true,
+          "requires": {
+            "@types/glob-stream": "*",
+            "@types/node": "*",
+            "@types/vinyl": "*"
+          }
+        },
+        "@types/whatwg-url": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+          "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-ZrJDWpvg75LTGX4XwuneY9s6bF3OeZcGTpoGh3zDV9ytzcHMFsRrMIaLBRJZQMBoGyKs6unBQfVdrLZiYfb1zQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@types/yeoman-generator": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yeoman-generator/-/yeoman-generator-2.0.3.tgz",
+          "integrity": "sha512-vch2UFd6k7DdfWEv/alRwZIRXQoxZNUDpfLOK24+005dzE1HVnwSWfETF3WxJnWlsOcH87wU4uzldAE/7F/6Lw==",
+          "requires": {
+            "@types/events": "*",
+            "@types/inquirer": "*"
+          }
+        },
+        "@types/yeoman-test": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/@types/yeoman-test/-/yeoman-test-1.7.4.tgz",
+          "integrity": "sha512-nppkWxmwWX2yuvuHqWjYZOxMuhjeKJ0CK6IONDBzYiLEC7l5dQR9RMTyBqtIXKrzX7PDMQmZDsKHfWds7anI7Q==",
+          "requires": {
+            "@types/events": "*",
+            "@types/yeoman-generator": "*"
+          }
+        },
+        "@webcomponents/webcomponentsjs": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
+          "integrity": "sha512-eLH04VBMpuZGzBIhOnUjECcQPEPcmfhWEijW9u1B5I+2PPYdWf3vWUExdDxu4Y3GljRSTCOlWnGtS9tpzmXMyQ==",
+          "dev": true
+        },
+        "abbrev": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+        },
+        "accepts": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+          "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.24",
+            "negotiator": "0.6.2"
+          }
+        },
+        "accessibility-developer-tools": {
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+          "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+          "dev": true
+        },
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+            }
+          }
+        },
+        "adm-zip": {
+          "version": "0.4.13",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+          "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
+          "dev": true,
+          "optional": true
+        },
+        "after": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+          "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+          "dev": true
+        },
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          },
+          "dependencies": {
+            "es6-promisify": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+              "requires": {
+                "es6-promise": "^4.0.3"
+              }
+            }
+          }
+        },
+        "ajv": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "optional": true
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ansi-colors": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+          "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+          "requires": {
+            "ansi-wrap": "^0.1.0"
+          }
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "ansi-gray": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+          "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+          "requires": {
+            "ansi-wrap": "0.1.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "ansi-wrap": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+          "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+        },
+        "any-promise": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+          "dev": true
+        },
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
+          }
+        },
+        "append-field": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+          "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=",
+          "dev": true
+        },
+        "archiver": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+          "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^1.3.0",
+            "async": "^2.0.0",
+            "buffer-crc32": "^0.2.1",
+            "glob": "^7.0.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0",
+            "tar-stream": "^1.5.0",
+            "zip-stream": "^1.2.0"
+          }
+        },
+        "archiver-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+          "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.0",
+            "graceful-fs": "^4.1.0",
+            "lazystream": "^1.0.0",
+            "lodash": "^4.8.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-back": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+          "dev": true
+        },
+        "array-differ": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+          "dev": true
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "array-from": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+          "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+        },
+        "arraybuffer.slice": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+          "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "async-each": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+          "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+          "dev": true
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+          "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "dev": true
+        },
+        "atob": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+          "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+        },
+        "atob-lite": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+          "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+              "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+          "dev": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+              "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+              "dev": true
+            }
+          }
+        },
+        "babel-helper-evaluate-path": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
+          "integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA==",
+          "dev": true
+        },
+        "babel-helper-flip-expressions": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+          "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0=",
+          "dev": true
+        },
+        "babel-helper-is-nodes-equiv": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+          "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
+          "dev": true
+        },
+        "babel-helper-is-void-0": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+          "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4=",
+          "dev": true
+        },
+        "babel-helper-mark-eval-scopes": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+          "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI=",
+          "dev": true
+        },
+        "babel-helper-remove-or-void": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+          "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=",
+          "dev": true
+        },
+        "babel-helper-to-multiple-sequence-expressions": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
+          "integrity": "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==",
+          "dev": true
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "dev": true,
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        },
+        "babel-plugin-minify-builtins": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
+          "integrity": "sha512-wpqbN7Ov5hsNwGdzuzvFcjgRlzbIeVv1gMIlICbPj0xkexnfoIDe7q+AZHMkQmAE/F9R5jkrB6TLfTegImlXag==",
+          "dev": true
+        },
+        "babel-plugin-minify-constant-folding": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
+          "integrity": "sha512-Vj97CTn/lE9hR1D+jKUeHfNy+m1baNiJ1wJvoGyOBUx7F7kJqDZxr9nCHjO/Ad+irbR3HzR6jABpSSA29QsrXQ==",
+          "dev": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-dead-code-elimination": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz",
+          "integrity": "sha512-XQteBGXlgEoAKc/BhO6oafUdT4LBa7ARi55mxoyhLHNuA+RlzRmeMAfc31pb/UqU01wBzRc36YqHQzopnkd/6Q==",
+          "dev": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0",
+            "babel-helper-mark-eval-scopes": "^0.4.3",
+            "babel-helper-remove-or-void": "^0.4.3",
+            "lodash.some": "^4.6.0"
+          }
+        },
+        "babel-plugin-minify-flip-comparisons": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+          "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
+          "dev": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-guarded-expressions": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz",
+          "integrity": "sha1-zHCbRFP9IbHzAod0RMifiEJ845c=",
+          "dev": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-infinity": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+          "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco=",
+          "dev": true
+        },
+        "babel-plugin-minify-mangle-names": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
+          "integrity": "sha512-3jdNv6hCAw6fsX1p2wBGPfWuK69sfOjfd3zjUXkbq8McbohWy23tpXfy5RnToYWggvqzuMOwlId1PhyHOfgnGw==",
+          "dev": true,
+          "requires": {
+            "babel-helper-mark-eval-scopes": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-numeric-literals": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+          "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw=",
+          "dev": true
+        },
+        "babel-plugin-minify-replace": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
+          "integrity": "sha512-aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q==",
+          "dev": true
+        },
+        "babel-plugin-minify-simplify": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.0.tgz",
+          "integrity": "sha512-TM01J/YcKZ8XIQd1Z3nF2AdWHoDsarjtZ5fWPDksYZNsoOjQ2UO2EWm824Ym6sp127m44gPlLFiO5KFxU8pA5Q==",
+          "dev": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3",
+            "babel-helper-is-nodes-equiv": "^0.0.1",
+            "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-type-constructors": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+          "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
+          "dev": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-transform-inline-consecutive-adds": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+          "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE=",
+          "dev": true
+        },
+        "babel-plugin-transform-member-expression-literals": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+          "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
+          "dev": true
+        },
+        "babel-plugin-transform-merge-sibling-variables": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+          "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
+          "dev": true
+        },
+        "babel-plugin-transform-minify-booleans": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+          "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
+          "dev": true
+        },
+        "babel-plugin-transform-property-literals": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+          "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "babel-plugin-transform-regexp-constructors": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+          "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU=",
+          "dev": true
+        },
+        "babel-plugin-transform-remove-console": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+          "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
+          "dev": true
+        },
+        "babel-plugin-transform-remove-debugger": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+          "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
+          "dev": true
+        },
+        "babel-plugin-transform-remove-undefined": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
+          "integrity": "sha512-+M7fJYFaEE/M9CXa0/IRkDbiV3wRELzA1kKQFCJ4ifhrzLKn/9VCCgj9OFmYWwBd8IB48YdgPkHYtbYq+4vtHQ==",
+          "dev": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-transform-simplify-comparison-operators": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+          "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
+          "dev": true
+        },
+        "babel-plugin-transform-undefined-to-void": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+          "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
+          "dev": true
+        },
+        "babel-preset-minify": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz",
+          "integrity": "sha512-xj1s9Mon+RFubH569vrGCayA9Fm2GMsCgDRm1Jb8SgctOB7KFcrVc2o8K3YHUyMz+SWP8aea75BoS8YfsXXuiA==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-minify-builtins": "^0.5.0",
+            "babel-plugin-minify-constant-folding": "^0.5.0",
+            "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+            "babel-plugin-minify-flip-comparisons": "^0.4.3",
+            "babel-plugin-minify-guarded-expressions": "^0.4.3",
+            "babel-plugin-minify-infinity": "^0.4.3",
+            "babel-plugin-minify-mangle-names": "^0.5.0",
+            "babel-plugin-minify-numeric-literals": "^0.4.3",
+            "babel-plugin-minify-replace": "^0.5.0",
+            "babel-plugin-minify-simplify": "^0.5.0",
+            "babel-plugin-minify-type-constructors": "^0.4.3",
+            "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+            "babel-plugin-transform-member-expression-literals": "^6.9.4",
+            "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+            "babel-plugin-transform-minify-booleans": "^6.9.4",
+            "babel-plugin-transform-property-literals": "^6.9.4",
+            "babel-plugin-transform-regexp-constructors": "^0.4.3",
+            "babel-plugin-transform-remove-console": "^6.9.4",
+            "babel-plugin-transform-remove-debugger": "^6.9.4",
+            "babel-plugin-transform-remove-undefined": "^0.5.0",
+            "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+            "babel-plugin-transform-undefined-to-void": "^6.9.4",
+            "lodash.isplainobject": "^4.0.6"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+            },
+            "globals": {
+              "version": "9.18.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+              "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          },
+          "dependencies": {
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+              "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+            }
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
+          "dev": true
+        },
+        "backo2": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+          "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base": {
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+          "dev": true
+        },
+        "base64-js": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+          "dev": true
+        },
+        "base64id": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+          "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+          "dev": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "beeper": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+          "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+        },
+        "before-after-hook": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+          "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+          "dev": true
+        },
+        "better-assert": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+          "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+          "dev": true,
+          "requires": {
+            "callsite": "1.0.0"
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true
+        },
+        "binaryextensions": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
+          "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg=="
+        },
+        "bl": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "blob": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+          "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+          "dev": true
+        },
+        "body-parser": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+          "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "http-errors": "1.7.2",
+            "iconv-lite": "0.4.24",
+            "on-finished": "~2.3.0",
+            "qs": "6.7.0",
+            "raw-body": "2.4.0",
+            "type-is": "~1.6.17"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+              "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+              "dev": true
+            }
+          }
+        },
+        "bower": {
+          "version": "1.8.8",
+          "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.8.tgz",
+          "integrity": "sha512-1SrJnXnkP9soITHptSO+ahx3QKp3cVzn8poI6ujqc5SeOkg5iqM1pK9H+DSc2OQ8SnO0jC/NG4Ur/UIwy7574A==",
+          "dev": true
+        },
+        "bower-config": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
+          "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.3",
+            "mout": "^1.0.0",
+            "optimist": "^0.6.1",
+            "osenv": "^0.1.3",
+            "untildify": "^2.1.0"
+          }
+        },
+        "bower-json": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.8.1.tgz",
+          "integrity": "sha1-lsFHIyQa5kZqnFLhbKoyYjqIOEM=",
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.4.0",
+            "ext-name": "^3.0.0",
+            "graceful-fs": "^4.1.3",
+            "intersect": "^1.0.1"
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
+          "integrity": "sha1-Ob4H6Xmy/I4DqUY0IF7ZQiNz04E=",
+          "dev": true
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+          "dev": true,
+          "requires": {
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "browser-capabilities": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
+          "integrity": "sha512-BezMQhbQklxjRQpZZQ8tnbzEo6AldUwMh8/PeWt5/CTBSwByQRXZEAK2fbnEahQ4poeeaI0suAYRq25A1YGOmw==",
+          "dev": true,
+          "requires": {
+            "@types/ua-parser-js": "^0.7.31",
+            "ua-parser-js": "^0.7.15"
+          }
+        },
+        "browser-stdout": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+          "dev": true,
+          "requires": {
+            "pako": "~0.2.0"
+          }
+        },
+        "browserstack": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.2.tgz",
+          "integrity": "sha512-+6AFt9HzhKykcPF79W6yjEUJcdvZOV0lIXdkORXMJftGrDl0OKWqRF4GHqpDNkxiceDT/uB7Fb/aDwktvXX7dg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "https-proxy-agent": "^2.2.1"
+          }
+        },
+        "btoa-lite": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+          "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+          "dev": true
+        },
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "buffer-alloc": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+          "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+          "requires": {
+            "buffer-alloc-unsafe": "^1.1.0",
+            "buffer-fill": "^1.0.0"
+          }
+        },
+        "buffer-alloc-unsafe": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+        },
+        "buffer-crc32": {
+          "version": "0.2.13",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+          "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+          "dev": true
+        },
+        "buffer-fill": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+        },
+        "busboy": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+          "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+          "dev": true,
+          "requires": {
+            "dicer": "0.2.5",
+            "readable-stream": "1.1.x"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
+            }
+          }
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+          "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsite": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+          "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+          "dev": true
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+        },
+        "camel-case": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+          "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          }
+        },
+        "cancel-token": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+          "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+          "dev": true,
+          "requires": {
+            "@types/node": "^4.0.30"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "4.9.3",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.9.3.tgz",
+              "integrity": "sha512-Q9eESThBvAbfEzznF1qTAKUoPbJEbK3lTSO0S3mICvmG/vUSZ+HnCtidpuB58Po7CJt5A2goKsDiYScN8d1V4A==",
+              "dev": true
+            }
+          }
+        },
+        "capture-stack-trace": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+          "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+          "dev": true
+        },
+        "charenc": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+          "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+          "dev": true
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "dev": true,
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          }
+        },
+        "chownr": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+          "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+          "dev": true
+        },
+        "ci-info": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+          "dev": true
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "clean-css": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+          "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "cleankill": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
+          "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE=",
+          "dev": true
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "cli-table": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+          "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+          "requires": {
+            "colors": "1.0.3"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+            }
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "clone-buffer": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+          "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
+        "cloneable-readable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+          "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "process-nextick-args": "^2.0.0",
+            "readable-stream": "^2.3.5"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+          "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.1",
+            "color-string": "^1.5.2"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "color-string": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+          "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+          "dev": true,
+          "requires": {
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
+          }
+        },
+        "color-support": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+          "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+        },
+        "colornames": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+          "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+          "dev": true
+        },
+        "colorspace": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+          "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+          "dev": true,
+          "requires": {
+            "color": "3.0.x",
+            "text-hex": "1.0.x"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "command-line-args": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+          "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+          "dev": true,
+          "requires": {
+            "array-back": "^3.0.1",
+            "find-replace": "^3.0.0",
+            "lodash.camelcase": "^4.3.0",
+            "typical": "^4.0.0"
+          }
+        },
+        "command-line-commands": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-2.0.1.tgz",
+          "integrity": "sha512-m8c2p1DrNd2ruIAggxd/y6DgygQayf6r8RHwchhXryaLF8I6koYjoYroVP+emeROE9DXN5b9sP1Gh+WtvTTdtQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0"
+          },
+          "dependencies": {
+            "array-back": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+              "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+              "dev": true,
+              "requires": {
+                "typical": "^2.6.1"
+              }
+            },
+            "typical": {
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+              "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+              "dev": true
+            }
+          }
+        },
+        "command-line-usage": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
+          "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0",
+            "chalk": "^2.4.1",
+            "table-layout": "^0.4.3",
+            "typical": "^2.6.1"
+          },
+          "dependencies": {
+            "array-back": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+              "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+              "dev": true,
+              "requires": {
+                "typical": "^2.6.1"
+              }
+            },
+            "typical": {
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+              "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+              "dev": true
+            }
+          }
+        },
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+        },
+        "component-bind": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+          "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "component-inherit": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+          "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+          "dev": true
+        },
+        "compress-commons": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+          "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "^0.2.1",
+            "crc32-stream": "^2.0.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "compressible": {
+          "version": "2.0.17",
+          "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+          "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+          "dev": true,
+          "requires": {
+            "mime-db": ">= 1.40.0 < 2"
+          }
+        },
+        "compression": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+          "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.5",
+            "bytes": "3.0.0",
+            "compressible": "~2.0.16",
+            "debug": "2.6.9",
+            "on-headers": "~1.0.2",
+            "safe-buffer": "5.1.2",
+            "vary": "~1.1.2"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "content-disposition": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+          "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+          "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+          "dev": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+          "dev": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cors": {
+          "version": "2.8.5",
+          "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+          "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4",
+            "vary": "^1"
+          }
+        },
+        "crc": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+          "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.1.0"
+          }
+        },
+        "crc32-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+          "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+          "dev": true,
+          "requires": {
+            "crc": "^3.4.4",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+          "dev": true,
+          "requires": {
+            "capture-stack-trace": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "crypt": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+          "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+          "dev": true
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+          "dev": true
+        },
+        "css-slam": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/css-slam/-/css-slam-2.1.2.tgz",
+          "integrity": "sha512-cObrY+mhFEmepWpua6EpMrgRNTQ0eeym+kvR0lukI6hDEzK7F8himEDS4cJ9+fPHCoArTzVrrR0d+oAUbTR1NA==",
+          "dev": true,
+          "requires": {
+            "command-line-args": "^5.0.2",
+            "command-line-usage": "^5.0.5",
+            "dom5": "^3.0.0",
+            "parse5": "^4.0.0",
+            "shady-css-parser": "^0.1.0"
+          }
+        },
+        "css-what": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+          "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+          "dev": true
+        },
+        "cssbeautify": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
+          "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c=",
+          "dev": true
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+          "dev": true,
+          "requires": {
+            "array-find-index": "^1.0.1"
+          }
+        },
+        "dargs": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-6.1.0.tgz",
+          "integrity": "sha512-5dVBvpBLBnPwSsYXqfybFyehMmC/EenKEcf23AhCTgTf48JFBbmJKqoZBsERDnjL0FyiVTYWdFsRfTLHxLyKdQ==",
+          "dev": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "dateformat": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "deepmerge": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+          "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==",
+          "dev": true
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "del": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+          "dev": true,
+          "requires": {
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "globby": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+              "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+              "dev": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                  "dev": true
+                }
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "dev": true
+        },
+        "depcheck": {
+          "version": "0.6.11",
+          "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.6.11.tgz",
+          "integrity": "sha512-wTVJ8cNilB8NfkzoBblcYqsB8LRfbjqKEwAOLD3YXIRigktSM7/lS9xQfVkAVujhjstmiQMZR0hkdHSnQxzb9A==",
+          "requires": {
+            "babel-traverse": "^6.7.3",
+            "babylon": "^6.1.21",
+            "builtin-modules": "^1.1.1",
+            "deprecate": "^1.0.0",
+            "deps-regex": "^0.1.4",
+            "js-yaml": "^3.4.2",
+            "lodash": "^4.5.1",
+            "minimatch": "^3.0.2",
+            "require-package-name": "^2.0.1",
+            "walkdir": "0.0.11",
+            "yargs": "^8.0.2"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+            }
+          }
+        },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
+        },
+        "deprecate": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.1.0.tgz",
+          "integrity": "sha512-b5dDNQYdy2vW9WXUD8+RQlfoxvqztLLhDE+T7Gd37I5E8My7nJkKu6FmhdDeRWJ8B+yjZKuwjCta8pgi8kgSqA=="
+        },
+        "deprecation": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+          "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+          "dev": true
+        },
+        "deps-regex": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
+          "integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ="
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+          "dev": true
+        },
+        "detect-conflict": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
+          "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
+        },
+        "detect-file": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+          "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+          "dev": true,
+          "requires": {
+            "fs-exists-sync": "^0.1.0"
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "detect-node": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+          "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+          "dev": true
+        },
+        "diagnostics": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+          "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+          "dev": true,
+          "requires": {
+            "colorspace": "1.1.x",
+            "enabled": "1.0.x",
+            "kuler": "1.0.x"
+          }
+        },
+        "dicer": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+          "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.1.x",
+            "streamsearch": "0.1.2"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
+            }
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+          "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          },
+          "dependencies": {
+            "path-type": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "dom-urls": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+          "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
+          "dev": true,
+          "requires": {
+            "urijs": "^1.16.1"
+          }
+        },
+        "dom5": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.1.tgz",
+          "integrity": "sha512-JPFiouQIr16VQ4dX6i0+Hpbg3H2bMKPmZ+WZgBOSSvOPx9QHwwY8sPzeM2baUtViESYto6wC2nuZOMC/6gulcA==",
+          "dev": true,
+          "requires": {
+            "@types/parse5": "^2.2.34",
+            "clone": "^2.1.0",
+            "parse5": "^4.0.0"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "duplexer2": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+        },
+        "duplexify": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+          "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+          "dev": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "editions": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+          "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+          "requires": {
+            "errlop": "^1.1.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+          "dev": true
+        },
+        "ejs": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
+          "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
+        },
+        "emitter-component": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+          "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=",
+          "dev": true
+        },
+        "enabled": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+          "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+          "dev": true,
+          "requires": {
+            "env-variable": "0.0.x"
+          }
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+          "dev": true
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "ends-with": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
+          "integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o=",
+          "dev": true
+        },
+        "engine.io": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
+          "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "base64id": "1.0.0",
+            "cookie": "0.3.1",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.0",
+            "ws": "~6.1.0"
+          },
+          "dependencies": {
+            "cookie": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+              "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+              "dev": true
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "engine.io-client": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+          "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "component-inherit": "0.0.3",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.1",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "~6.1.0",
+            "xmlhttprequest-ssl": "~1.5.4",
+            "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+              "dev": true
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "engine.io-parser": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+          "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+          "dev": true,
+          "requires": {
+            "after": "0.8.2",
+            "arraybuffer.slice": "~0.0.7",
+            "base64-arraybuffer": "0.1.5",
+            "blob": "0.0.5",
+            "has-binary2": "~1.0.2"
+          }
+        },
+        "env-variable": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+          "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==",
+          "dev": true
+        },
+        "errlop": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
+          "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
+          "requires": {
+            "editions": "^2.1.2"
+          }
+        },
+        "error": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+          "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+          "requires": {
+            "string-template": "~0.2.1",
+            "xtend": "~4.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+          "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+        },
+        "es6-promisify": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz",
+          "integrity": "sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==",
+          "dev": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+          "requires": {
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+            },
+            "estraverse": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+            },
+            "source-map": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+              "optional": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            },
+            "ansi-escapes": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+              "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
+            "chardet": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+              "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "external-editor": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+              "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+              "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+              "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+            },
+            "figures": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+              "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "inquirer": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+              "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+              "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+              "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+              "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            }
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+          "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+          "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+          "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+        },
+        "etag": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+          "dev": true
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "requires": {
+            "fill-range": "^2.1.0"
+          }
+        },
+        "expand-tilde": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.1"
+          }
+        },
+        "express": {
+          "version": "4.17.1",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+          "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.7",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.19.0",
+            "content-disposition": "0.5.3",
+            "content-type": "~1.0.4",
+            "cookie": "0.4.0",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "~1.1.2",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.3",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.5",
+            "qs": "6.7.0",
+            "range-parser": "~1.2.1",
+            "safe-buffer": "5.1.2",
+            "send": "0.17.1",
+            "serve-static": "1.14.1",
+            "setprototypeof": "1.1.1",
+            "statuses": "~1.5.0",
+            "type-is": "~1.6.18",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+              "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+              "dev": true
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true
+            },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+              "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+              "dev": true
+            },
+            "send": {
+              "version": "0.17.1",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+              "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+              "dev": true,
+              "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+              }
+            }
+          }
+        },
+        "ext-list": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+          "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+          "dev": true,
+          "requires": {
+            "mime-db": "^1.28.0"
+          }
+        },
+        "ext-name": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-3.0.0.tgz",
+          "integrity": "sha1-B+RBhzfLH1E8MsbqSNi4yOBHGrs=",
+          "dev": true,
+          "requires": {
+            "ends-with": "^0.2.0",
+            "ext-list": "^2.0.0",
+            "meow": "^3.1.0",
+            "sort-keys-length": "^1.0.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+              "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "dev": true,
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          },
+          "dependencies": {
+            "tmp": {
+              "version": "0.0.29",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+              "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.1"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "extract-zip": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+          "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+          "requires": {
+            "concat-stream": "1.6.2",
+            "debug": "2.6.9",
+            "mkdirp": "0.5.1",
+            "yauzl": "2.4.1"
+          },
+          "dependencies": {
+            "fd-slicer": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+              "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+              "requires": {
+                "pend": "~1.2.0"
+              }
+            },
+            "yauzl": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+              "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+              "requires": {
+                "fd-slicer": "~1.0.1"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+          "dev": true
+        },
+        "fancy-log": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+          "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+          "requires": {
+            "ansi-gray": "^0.1.1",
+            "color-support": "^1.1.3",
+            "parse-node-version": "^1.0.0",
+            "time-stamp": "^1.0.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+          "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+            },
+            "braces": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                  "requires": {
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+              "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+              "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                  "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                  "requires": {
+                    "is-extglob": "^2.1.0"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+              "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+            },
+            "is-glob": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+              "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            }
+          }
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+        },
+        "fast-safe-stringify": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+          "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==",
+          "dev": true
+        },
+        "fd-slicer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        },
+        "fecha": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+          "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+        },
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "filled-array": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+          "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
+          "dev": true
+        },
+        "finalhandler": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+          "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.3",
+            "statuses": "~1.5.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "find-port": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/find-port/-/find-port-1.0.1.tgz",
+          "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
+          "dev": true,
+          "requires": {
+            "async": "~0.2.9"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+              "dev": true
+            }
+          }
+        },
+        "find-replace": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+          "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "^3.0.1"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "findup-sync": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+          "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^0.1.0",
+            "is-glob": "^2.0.1",
+            "micromatch": "^2.3.7",
+            "resolve-dir": "^0.1.0"
+          }
+        },
+        "first-chunk-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+          "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+        },
+        "flat-cache": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+          "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+          "requires": {
+            "circular-json": "^0.3.1",
+            "graceful-fs": "^4.1.2",
+            "rimraf": "~2.6.2",
+            "write": "^0.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+          "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^3.2.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "dev": true
+        },
+        "fork-stream": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+          "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "formatio": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+          "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+          "dev": true,
+          "requires": {
+            "samsam": "1.x"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+          "dev": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "freeport": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
+          "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
+          "dev": true,
+          "optional": true
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "dev": true
+        },
+        "fs-constants": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+          "dev": true
+        },
+        "fs-exists-sync": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+          "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+              "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            }
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fsevents": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "gh-got": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
+          "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+          "requires": {
+            "got": "^7.0.0",
+            "is-plain-obj": "^1.1.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            },
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "github-username": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
+          "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
+          "requires": {
+            "gh-got": "^6.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "glob-stream": {
+          "version": "5.3.5",
+          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+          "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+          "requires": {
+            "extend": "^3.0.0",
+            "glob": "^5.0.3",
+            "glob-parent": "^3.0.0",
+            "micromatch": "^2.3.7",
+            "ordered-read-streams": "^0.3.0",
+            "through2": "^0.6.0",
+            "to-absolute-glob": "^0.1.1",
+            "unique-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+              "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+              "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+              "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            },
+            "through2": {
+              "version": "0.6.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "requires": {
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
+              }
+            }
+          }
+        },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+          "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "global-modules": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+          "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+          "dev": true,
+          "requires": {
+            "global-prefix": "^0.1.4",
+            "is-windows": "^0.2.0"
+          },
+          "dependencies": {
+            "is-windows": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+              "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+              "dev": true
+            }
+          }
+        },
+        "global-prefix": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+          "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.0",
+            "ini": "^1.3.4",
+            "is-windows": "^0.2.0",
+            "which": "^1.2.12"
+          },
+          "dependencies": {
+            "is-windows": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+              "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+              "dev": true
+            }
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        },
+        "globby": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+          "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
+        "glogg": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+          "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
+          "requires": {
+            "sparkles": "^1.0.0"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+              "dev": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+          "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+        },
+        "grouped-queue": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
+          "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
+          "requires": {
+            "lodash": "^4.17.2"
+          }
+        },
+        "growl": {
+          "version": "1.10.5",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+        },
+        "gulp-eslint": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-4.0.2.tgz",
+          "integrity": "sha512-fcFUQzFsN6dJ6KZlG+qPOEkqfcevRUXgztkYCvhNvJeSvOicC8ucutN4qR/ID8LmNZx9YPIkBzazTNnVvbh8wg==",
+          "requires": {
+            "eslint": "^4.0.0",
+            "fancy-log": "^1.3.2",
+            "plugin-error": "^1.0.0"
+          }
+        },
+        "gulp-if": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+          "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
+          "dev": true,
+          "requires": {
+            "gulp-match": "^1.0.3",
+            "ternary-stream": "^2.0.1",
+            "through2": "^2.0.1"
+          }
+        },
+        "gulp-match": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+          "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.3"
+          }
+        },
+        "gulp-mocha": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-6.0.0.tgz",
+          "integrity": "sha512-FfBldW5ttnDpKf4Sg6/BLOOKCCbr5mbixDGK1t02/8oSrTCwNhgN/mdszG3cuQuYNzuouUdw4EH/mlYtgUscPg==",
+          "requires": {
+            "dargs": "^5.1.0",
+            "execa": "^0.10.0",
+            "mocha": "^5.2.0",
+            "npm-run-path": "^2.0.2",
+            "plugin-error": "^1.0.1",
+            "supports-color": "^5.4.0",
+            "through2": "^2.0.3"
+          },
+          "dependencies": {
+            "dargs": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+              "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
+            },
+            "execa": {
+              "version": "0.10.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+              "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+              "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            }
+          }
+        },
+        "gulp-sourcemaps": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+          "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+          "requires": {
+            "convert-source-map": "^1.1.1",
+            "graceful-fs": "^4.1.2",
+            "strip-bom": "^2.0.0",
+            "through2": "^2.0.0",
+            "vinyl": "^1.0.0"
+          }
+        },
+        "gulp-tslint": {
+          "version": "8.1.4",
+          "resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-8.1.4.tgz",
+          "integrity": "sha512-wBoZIEMJRz9urHwolsvQpngA9l931p6g/Liwz1b/KrsVP6jEBFZv/o0NS1TFCQZi/l8mXxz8+v3twhf4HOXxPQ==",
+          "requires": {
+            "@types/fancy-log": "1.3.0",
+            "ansi-colors": "^1.0.1",
+            "fancy-log": "1.3.3",
+            "map-stream": "~0.0.7",
+            "plugin-error": "1.0.1",
+            "through": "~2.3.8"
+          }
+        },
+        "gulp-typescript": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.4.tgz",
+          "integrity": "sha512-bZosNvbUGzFA4bjjWoUPyjU5vfgJSzlYKkU0Jutbsrj+td8yvtqxethhqfzB9MwyamaUODIuidj5gIytZ523Bw==",
+          "requires": {
+            "gulp-util": "~3.0.7",
+            "source-map": "~0.5.3",
+            "through2": "~2.0.1",
+            "vinyl-fs": "~2.4.3"
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+          "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-uniq": "^1.0.2",
+            "beeper": "^1.0.0",
+            "chalk": "^1.0.0",
+            "dateformat": "^2.0.0",
+            "fancy-log": "^1.1.0",
+            "gulplog": "^1.0.0",
+            "has-gulplog": "^0.1.0",
+            "lodash._reescape": "^3.0.0",
+            "lodash._reevaluate": "^3.0.0",
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.template": "^3.0.0",
+            "minimist": "^1.1.0",
+            "multipipe": "^0.1.2",
+            "object-assign": "^3.0.0",
+            "replace-ext": "0.0.1",
+            "through2": "^2.0.0",
+            "vinyl": "^0.5.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "clone": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+            },
+            "dateformat": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+              "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+            },
+            "duplexer2": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+              "requires": {
+                "readable-stream": "~1.1.9"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+              "requires": {
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
+              }
+            },
+            "lodash.templatesettings": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+              "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+              "requires": {
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
+              }
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+              "requires": {
+                "duplexer2": "0.0.2"
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+              "requires": {
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
+                "replace-ext": "0.0.1"
+              }
+            }
+          }
+        },
+        "gulplog": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+          "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+          "requires": {
+            "glogg": "^1.0.0"
+          }
+        },
+        "gunzip-maybe": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+          "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+          "dev": true,
+          "requires": {
+            "browserify-zlib": "^0.1.4",
+            "is-deflate": "^1.0.0",
+            "is-gzip": "^1.0.0",
+            "peek-stream": "^1.1.0",
+            "pumpify": "^1.3.3",
+            "through2": "^2.0.3"
+          }
+        },
+        "handle-thing": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+          "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+          "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            }
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-binary2": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+          "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+          "dev": true,
+          "requires": {
+            "isarray": "2.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+              "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+              "dev": true
+            }
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+          "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+          "dev": true
+        },
+        "has-cors": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+          "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "has-gulplog": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+          "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+          "requires": {
+            "sparkles": "^1.0.0"
+          }
+        },
+        "has-symbol-support-x": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+          "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+          "dev": true
+        },
+        "has-to-string-tag-x": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+          "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+          "requires": {
+            "has-symbol-support-x": "^1.4.1"
+          }
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "he": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+          "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+          "dev": true
+        },
+        "homedir-polyfill": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+          "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+          "dev": true,
+          "requires": {
+            "parse-passwd": "^1.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+          "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+        },
+        "hpack.js": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+          "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "obuf": "^1.0.0",
+            "readable-stream": "^2.0.1",
+            "wbuf": "^1.1.0"
+          }
+        },
+        "html-minifier": {
+          "version": "3.5.21",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+          "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+          "dev": true,
+          "requires": {
+            "camel-case": "3.0.x",
+            "clean-css": "4.2.x",
+            "commander": "2.17.x",
+            "he": "1.2.x",
+            "param-case": "2.1.x",
+            "relateurl": "0.2.x",
+            "uglify-js": "3.4.x"
+          }
+        },
+        "http-deceiver": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+          "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+          "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "^3.0.0",
+            "follow-redirects": "^1.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "0.17.4",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+          "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+          "dev": true,
+          "requires": {
+            "http-proxy": "^1.16.2",
+            "is-glob": "^3.1.0",
+            "lodash": "^4.17.2",
+            "micromatch": "^2.3.11"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+              "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+          "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+        },
+        "indent": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+          "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk=",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+          "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "interpret": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+        },
+        "intersect": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/intersect/-/intersect-1.0.1.tgz",
+          "integrity": "sha1-MyZQ4QhU2MCsWMGSvcJ6i/fnoww=",
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+        },
+        "ipaddr.js": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+          "dev": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "is-ci": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^1.5.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-deflate": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+          "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ=",
+          "dev": true
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-gzip": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+          "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
+          "dev": true
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+          "dev": true,
+          "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+          "dev": true
+        },
+        "is-object": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+          "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+          "dev": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+          "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+          "dev": true,
+          "requires": {
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+        },
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+        },
+        "is-potential-custom-element-name": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+          "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+          "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+          "dev": true
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+          "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+        },
+        "is-scoped": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
+          "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
+          "requires": {
+            "scoped-regex": "^1.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+        },
+        "is-valid-glob": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+          "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isbinaryfile": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+          "requires": {
+            "buffer-alloc": "^1.2.0"
+          }
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "dev": true
+        },
+        "istanbul": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+          "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+          "requires": {
+            "abbrev": "1.0.x",
+            "async": "1.x",
+            "escodegen": "1.8.x",
+            "esprima": "2.7.x",
+            "glob": "^5.0.15",
+            "handlebars": "^4.0.1",
+            "js-yaml": "3.x",
+            "mkdirp": "0.5.x",
+            "nopt": "3.x",
+            "once": "1.x",
+            "resolve": "1.1.x",
+            "supports-color": "^3.1.0",
+            "which": "^1.1.1",
+            "wordwrap": "^1.0.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+            },
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+            },
+            "resolve": {
+              "version": "1.1.7",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+            }
+          }
+        },
+        "istextorbinary": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.5.1.tgz",
+          "integrity": "sha512-pv/JNPWnfpwGjPx7JrtWTwsWsxkrK3fNzcEVnt92YKEIErps4Fsk49+qzCe9iQF2hjqK8Naqf8P9kzoeCuQI1g==",
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.1.3",
+            "textextensions": "^2.4.0"
+          }
+        },
+        "isurl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+          "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+          "requires": {
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+          "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "jsonschema": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+          "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+          "dev": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "just-extend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+          "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "kuler": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+          "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+          "dev": true,
+          "requires": {
+            "colornames": "^1.1.1"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+          "dev": true,
+          "requires": {
+            "package-json": "^4.0.0"
+          }
+        },
+        "launchpad": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/launchpad/-/launchpad-0.7.2.tgz",
+          "integrity": "sha512-nmfx8QWqCvAmukHPticyO3+frnUKp0tDKXz3Au570XHBE0G1lNyN+KSODHgTqIIEuCIAlAgpbWjI36Vjk1mDKA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "^2.0.1",
+            "browserstack": "^1.2.0",
+            "debug": "^2.2.0",
+            "plist": "^2.0.1",
+            "q": "^1.4.1",
+            "underscore": "^1.8.3"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.9.1",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+              "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "lazy-req": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+          "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
+          "dev": true
+        },
+        "lazystream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+          "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+          "requires": {
+            "readable-stream": "^2.0.5"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.12",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.12.tgz",
+          "integrity": "sha512-+CiwtLnsJhX03p20mwXuvhoebatoh5B3tt+VvYlrPgZC1g36y+RRbkufX95Xa+X4I59aWEacDFYwnJZiyBh9gA=="
+        },
+        "lodash._basecopy": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+        },
+        "lodash._basetostring": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+        },
+        "lodash._basevalues": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+          "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+        },
+        "lodash._isiterateecall": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+        },
+        "lodash._reescape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+          "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+        },
+        "lodash._reevaluate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+          "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+        },
+        "lodash._root": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+        },
+        "lodash.camelcase": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+          "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+          "dev": true
+        },
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+          "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+          "dev": true
+        },
+        "lodash.escape": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+          "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+          "requires": {
+            "lodash._root": "^3.0.0"
+          }
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+        },
+        "lodash.isequal": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+          "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+          "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+          "dev": true
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
+        },
+        "lodash.padend": {
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+          "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+          "dev": true
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+        },
+        "lodash.set": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+          "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+          "dev": true
+        },
+        "lodash.some": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+          "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+          "dev": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+          "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+          "dev": true
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "~3.0.0",
+            "lodash.templatesettings": "^4.0.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "~3.0.0"
+          }
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "logform": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/logform/-/logform-1.10.0.tgz",
+          "integrity": "sha512-em5ojIhU18fIMOw/333mD+ZLE2fis0EzXl1ZwHx4iQzmpQi6odNiY/t+ITNr33JZhT9/KEaH+UPIipr6a9EjWg==",
+          "dev": true,
+          "requires": {
+            "colors": "^1.2.1",
+            "fast-safe-stringify": "^2.0.4",
+            "fecha": "^2.3.3",
+            "ms": "^2.1.1",
+            "triple-beam": "^1.2.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+          "dev": true,
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "lower-case": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+          "dev": true
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "macos-release": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+          "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.22.5",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+          "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+          "dev": true,
+          "requires": {
+            "vlq": "^0.2.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        },
+        "map-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+          "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "matcher": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+          "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.4"
+          }
+        },
+        "math-random": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+          "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+        },
+        "md5": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+          "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+          "dev": true,
+          "requires": {
+            "charenc": "~0.0.1",
+            "crypt": "~0.0.1",
+            "is-buffer": "~1.1.1"
+          }
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mem-fs": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
+          "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
+          "requires": {
+            "through2": "^2.0.0",
+            "vinyl": "^1.1.0",
+            "vinyl-file": "^2.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-5.1.0.tgz",
+          "integrity": "sha512-2Yt2GCYEbcotYbIJagmow4gEtHDqzpq5XN94+yAx/NT5+bGqIjkXnm3KCUQfE6kRfScGp9IZknScoGRKu8L78w==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.6.0",
+            "ejs": "^2.5.9",
+            "glob": "^7.0.3",
+            "globby": "^8.0.1",
+            "isbinaryfile": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          },
+          "dependencies": {
+            "clone-stats": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+              "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+              "dev": true
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+              "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+              "dev": true
+            },
+            "vinyl": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+              "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+              "dev": true,
+              "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+              }
+            }
+          }
+        },
+        "memory-streams": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
+          "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
+          "requires": {
+            "readable-stream": "~1.0.2"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            }
+          }
+        },
+        "meow": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          }
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+          "dev": true
+        },
+        "merge-stream": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+          "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+          "requires": {
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "merge2": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+          "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+        },
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        },
+        "mime-db": {
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.40.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimatch-all": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch-all/-/minimatch-all-1.1.0.tgz",
+          "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mixin-deep": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+          "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+              "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "mocha": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+          "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+          "requires": {
+            "browser-stdout": "1.3.1",
+            "commander": "2.15.1",
+            "debug": "3.1.0",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.5",
+            "he": "1.1.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "supports-color": "5.4.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.15.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "he": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+              "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+            },
+            "supports-color": {
+              "version": "5.4.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+              "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "mout": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
+          "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "multer": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.1.tgz",
+          "integrity": "sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==",
+          "dev": true,
+          "requires": {
+            "append-field": "^1.0.0",
+            "busboy": "^0.2.11",
+            "concat-stream": "^1.5.2",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.1.1",
+            "on-finished": "^2.3.0",
+            "type-is": "^1.6.4",
+            "xtend": "^4.0.0"
+          }
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+          "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
+          }
+        },
+        "multipipe": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+          "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+          "dev": true,
+          "requires": {
+            "duplexer2": "^0.1.2",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
+          "dev": true
+        },
+        "mz": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+          "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+          "dev": true,
+          "requires": {
+            "any-promise": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "thenify-all": "^1.0.0"
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true,
+          "optional": true
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+          "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "native-promise-only": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+          "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+          "dev": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+        },
+        "negotiator": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+          "dev": true
+        },
+        "neo-async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+        },
+        "nise": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+          "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+          "requires": {
+            "@sinonjs/formatio": "^3.1.0",
+            "@sinonjs/text-encoding": "^0.7.1",
+            "just-extend": "^4.0.2",
+            "lolex": "^4.1.0",
+            "path-to-regexp": "^1.7.0"
+          },
+          "dependencies": {
+            "@sinonjs/formatio": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+              "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+              "requires": {
+                "@sinonjs/commons": "^1",
+                "@sinonjs/samsam": "^3.1.0"
+              }
+            },
+            "lolex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+              "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw=="
+            }
+          }
+        },
+        "no-case": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+          "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^1.1.1"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
+        },
+        "node-status-codes": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+          "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+          "dev": true
+        },
+        "nomnom": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+          "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+          "dev": true,
+          "requires": {
+            "chalk": "~0.4.0",
+            "underscore": "~1.6.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+              "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "~1.0.0",
+                "has-color": "~0.1.0",
+                "strip-ansi": "~0.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+              "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+              "dev": true
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "object-component": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+          "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+          "dev": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "requires": {
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "requires": {
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "obuf": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+          "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+          "dev": true
+        },
+        "octokit-pagination-methods": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+          "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+          "dev": true
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "dev": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "on-headers": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+          "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "one-time": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+          "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "opn": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+          "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+            }
+          }
+        },
+        "ordered-read-streams": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+          "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+          "requires": {
+            "is-stream": "^1.0.1",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "execa": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            }
+          }
+        },
+        "os-name": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+          "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+          "dev": true,
+          "requires": {
+            "macos-release": "^2.2.0",
+            "windows-release": "^3.1.0"
+          }
+        },
+        "os-shim": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+          "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-map": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+          "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+          "dev": true
+        },
+        "p-timeout": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+          "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+          "dev": true,
+          "requires": {
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
+          }
+        },
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+          "dev": true
+        },
+        "param-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+          "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "parse-node-version": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+          "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
+        },
+        "parse-passwd": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+          "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+          "dev": true
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+          "dev": true
+        },
+        "parseqs": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+          "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
+        },
+        "parseuri": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+          "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+          "dev": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+          "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            }
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "peek-stream": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+          "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "duplexify": "^3.5.0",
+            "through2": "^2.0.3"
+          }
+        },
+        "pem": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.2.tgz",
+          "integrity": "sha512-TOnPtq3ZFnCniOZ+rka4pk8UIze9xG1qI+wNE7EmkiR/cg+53uVvk5QbkWZ7M6RsuOxzz62FW1hlAobJr/lTOA==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^6.0.0",
+            "md5": "^2.2.1",
+            "os-tmpdir": "^1.0.1",
+            "which": "^1.3.1"
+          }
+        },
+        "pend": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+          "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "plist": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "base64-js": "1.2.0",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.x"
+          }
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            }
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+        },
+        "plylog": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/plylog/-/plylog-1.1.0.tgz",
+          "integrity": "sha512-/QnY5aSVaP54va6hruzNtAj02HpsLlAt7V5EndMrtq6ZUTZJKUja43rgiUtGXqm95yrSJjbZoPW0yQQQwLpoJA==",
+          "dev": true,
+          "requires": {
+            "logform": "^1.9.1",
+            "winston": "^3.0.0",
+            "winston-transport": "^4.2.0"
+          }
+        },
+        "polymer-analyzer": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.2.4.tgz",
+          "integrity": "sha512-JmxUhMajTuC18tLXbTtu2+aN2x9bTX+4MvCD4IZKJ0rtAL8jWi1iRLfogpHJB4Ig9Dc8EEEuEYipLuzPFl3vqA==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.0.0-beta.42",
+            "@babel/traverse": "^7.0.0-beta.42",
+            "@babel/types": "^7.0.0-beta.42",
+            "@types/babel-generator": "^6.25.1",
+            "@types/babel-traverse": "^6.25.2",
+            "@types/babel-types": "^6.25.1",
+            "@types/babylon": "^6.16.2",
+            "@types/chai-subset": "^1.3.0",
+            "@types/chalk": "^0.4.30",
+            "@types/clone": "^0.1.30",
+            "@types/cssbeautify": "^0.3.1",
+            "@types/doctrine": "^0.0.1",
+            "@types/is-windows": "^0.2.0",
+            "@types/minimatch": "^3.0.1",
+            "@types/parse5": "^2.2.34",
+            "@types/path-is-inside": "^1.0.0",
+            "@types/resolve": "0.0.6",
+            "@types/whatwg-url": "^6.4.0",
+            "babylon": "^7.0.0-beta.42",
+            "cancel-token": "^0.1.1",
+            "chalk": "^1.1.3",
+            "clone": "^2.0.0",
+            "cssbeautify": "^0.3.1",
+            "doctrine": "^2.0.2",
+            "dom5": "^3.0.0",
+            "indent": "0.0.2",
+            "is-windows": "^1.0.2",
+            "jsonschema": "^1.1.0",
+            "minimatch": "^3.0.4",
+            "parse5": "^4.0.0",
+            "path-is-inside": "^1.0.2",
+            "resolve": "^1.5.0",
+            "shady-css-parser": "^0.1.0",
+            "stable": "^0.1.6",
+            "strip-indent": "^2.0.0",
+            "vscode-uri": "=1.0.6",
+            "whatwg-url": "^6.4.0"
+          },
+          "dependencies": {
+            "@types/chalk": {
+              "version": "0.4.31",
+              "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
+              "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
+              "dev": true
+            },
+            "@types/resolve": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+              "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+              "dev": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "strip-indent": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+              "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "polymer-build": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-3.1.4.tgz",
+          "integrity": "sha512-OhTOPG5Y/tK2HqGZ5XA/CVDh+TuOaDv7wTZWXDCg6hxeMgNKuljDMn2coyGU5NLM0pLbS+gwFAc2ZJ5cWHCHNg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.0.0",
+            "@babel/plugin-external-helpers": "^7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-syntax-async-generators": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-import-meta": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-async-to-generator": "^7.0.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-instanceof": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-amd": "^7.0.0",
+            "@babel/plugin-transform-object-super": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@polymer/esm-amd-loader": "^1.0.0",
+            "@types/babel-types": "^6.25.1",
+            "@types/babylon": "^6.16.2",
+            "@types/gulp-if": "0.0.33",
+            "@types/html-minifier": "^3.5.1",
+            "@types/is-windows": "^0.2.0",
+            "@types/mz": "0.0.31",
+            "@types/parse5": "^2.2.34",
+            "@types/resolve": "0.0.7",
+            "@types/uuid": "^3.4.3",
+            "@types/vinyl": "^2.0.0",
+            "@types/vinyl-fs": "^2.4.8",
+            "babel-plugin-minify-guarded-expressions": "^0.4.3",
+            "babel-preset-minify": "^0.5.0",
+            "babylon": "^7.0.0-beta.42",
+            "css-slam": "^2.1.2",
+            "dom5": "^3.0.0",
+            "gulp-if": "^2.0.2",
+            "html-minifier": "^3.5.10",
+            "matcher": "^1.1.0",
+            "multipipe": "^1.0.2",
+            "mz": "^2.6.0",
+            "parse5": "^4.0.0",
+            "plylog": "^1.0.0",
+            "polymer-analyzer": "^3.1.3",
+            "polymer-bundler": "^4.0.9",
+            "polymer-project-config": "^4.0.3",
+            "regenerator-runtime": "^0.11.1",
+            "stream": "0.0.2",
+            "sw-precache": "^5.1.1",
+            "uuid": "^3.2.1",
+            "vinyl": "^1.2.0",
+            "vinyl-fs": "^2.4.4"
+          },
+          "dependencies": {
+            "@types/resolve": {
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
+              "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
+              "dev": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "@types/vinyl-fs": {
+              "version": "2.4.11",
+              "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
+              "integrity": "sha512-2OzQSfIr9CqqWMGqmcERE6Hnd2KY3eBVtFaulVo3sJghplUcaeMdL9ZjEiljcQQeHjheWY9RlNmumjIAvsBNaA==",
+              "dev": true,
+              "requires": {
+                "@types/glob-stream": "*",
+                "@types/node": "*",
+                "@types/vinyl": "*"
+              }
+            }
+          }
+        },
+        "polymer-bundler": {
+          "version": "4.0.10",
+          "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
+          "integrity": "sha512-nwlN3LQlQDqbZ2sUH3394C/dHZUDHq8tpdS5HARvPDb0Q9IXWD+znOR1cr7wSjF0EZN4LiUH5hWyUoV4QSjhpQ==",
+          "dev": true,
+          "requires": {
+            "@types/babel-generator": "^6.25.1",
+            "@types/babel-traverse": "^6.25.3",
+            "babel-generator": "^6.26.1",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "clone": "^2.1.0",
+            "command-line-args": "^5.0.2",
+            "command-line-usage": "^5.0.5",
+            "dom5": "^3.0.0",
+            "espree": "^3.5.2",
+            "magic-string": "^0.22.4",
+            "mkdirp": "^0.5.1",
+            "parse5": "^4.0.0",
+            "polymer-analyzer": "^3.2.2",
+            "rollup": "^1.3.0",
+            "source-map": "^0.5.6",
+            "vscode-uri": "=1.0.6"
+          }
+        },
+        "polymer-linter": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/polymer-linter/-/polymer-linter-3.0.1.tgz",
+          "integrity": "sha512-eDh2CeswZz4Rwf8gfYXpMN66pieq4qJvP9bH3m39LLGm81hRePo4N5OHoQzR5unen1PUdmtjDv0Iicz3dTYEZQ==",
+          "dev": true,
+          "requires": {
+            "@types/fast-levenshtein": "0.0.1",
+            "@types/parse5": "^2.2.34",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "cancel-token": "^0.1.1",
+            "css-what": "^2.1.0",
+            "dom5": "^3.0.0",
+            "fast-levenshtein": "^2.0.6",
+            "parse5": "^4.0.0",
+            "polymer-analyzer": "^3.0.0",
+            "shady-css-parser": "^0.1.0",
+            "stable": "^0.1.6",
+            "strip-indent": "^2.0.0",
+            "validate-element-name": "^2.1.1"
+          },
+          "dependencies": {
+            "strip-indent": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+              "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+              "dev": true
+            }
+          }
+        },
+        "polymer-project-config": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
+          "integrity": "sha512-Drr+Imq+znhBC8XSt9pMlmPixoGnIOmleV5SD6mto1zOGC5oCDbSNsQL2v89DWOk+9aSUO79vnWwOmEPDSvYfw==",
+          "dev": true,
+          "requires": {
+            "@types/parse5": "^2.2.34",
+            "browser-capabilities": "^1.0.0",
+            "jsonschema": "^1.1.1",
+            "minimatch-all": "^1.1.0",
+            "plylog": "^1.0.0",
+            "winston": "^3.0.0"
+          }
+        },
+        "polyserve": {
+          "version": "0.27.15",
+          "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.27.15.tgz",
+          "integrity": "sha512-AaFgANt+tUUVgHLw+BnaVYcn649JiwL1ru0TOZUKj1gGGn/Bq2S16gxql+1muGpRaAsgFu13Zu7k5XkwatwwSg==",
+          "dev": true,
+          "requires": {
+            "@types/compression": "^0.0.33",
+            "@types/content-type": "^1.1.0",
+            "@types/escape-html": "0.0.20",
+            "@types/express": "^4.0.36",
+            "@types/mime": "^2.0.0",
+            "@types/mz": "0.0.29",
+            "@types/opn": "^3.0.28",
+            "@types/parse5": "^2.2.34",
+            "@types/pem": "^1.8.1",
+            "@types/resolve": "0.0.6",
+            "@types/serve-static": "^1.7.31",
+            "@types/spdy": "^3.4.1",
+            "bower-config": "^1.4.1",
+            "browser-capabilities": "^1.0.0",
+            "command-line-args": "^5.0.2",
+            "command-line-usage": "^5.0.5",
+            "compression": "^1.6.2",
+            "content-type": "^1.0.2",
+            "cors": "^2.8.4",
+            "escape-html": "^1.0.3",
+            "express": "^4.8.5",
+            "find-port": "^1.0.1",
+            "http-proxy-middleware": "^0.17.2",
+            "lru-cache": "^4.0.2",
+            "mime": "^2.3.1",
+            "mz": "^2.4.0",
+            "opn": "^3.0.2",
+            "pem": "^1.8.3",
+            "polymer-build": "^3.1.0",
+            "polymer-project-config": "^4.0.0",
+            "requirejs": "^2.3.4",
+            "resolve": "^1.5.0",
+            "send": "^0.16.2",
+            "spdy": "^3.3.3"
+          },
+          "dependencies": {
+            "@types/mz": {
+              "version": "0.0.29",
+              "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
+              "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
+              "dev": true,
+              "requires": {
+                "@types/bluebird": "*",
+                "@types/node": "*"
+              }
+            },
+            "@types/resolve": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+              "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+              "dev": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            }
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+        },
+        "pretty-bytes": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+          "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+        },
+        "private": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+        },
+        "proxy-addr": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+          "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+          "dev": true,
+          "requires": {
+            "forwarded": "~0.1.2",
+            "ipaddr.js": "1.9.0"
+          }
+        },
+        "proxy-from-env": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+          "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "psl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+          "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
+          "dev": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+          "dev": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+              "dev": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "puppeteer": {
+          "version": "1.18.1",
+          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.18.1.tgz",
+          "integrity": "sha512-luUy0HPSuWPsPZ1wAp6NinE0zgetWtudf5zwZ6dHjMWfYpTQcmKveFRox7VBNhQ98OjNA9PQ9PzQyX8k/KrxTg==",
+          "requires": {
+            "debug": "^4.1.0",
+            "extract-zip": "^1.6.6",
+            "https-proxy-agent": "^2.2.1",
+            "mime": "^2.0.3",
+            "progress": "^2.0.1",
+            "proxy-from-env": "^1.0.0",
+            "rimraf": "^2.6.1",
+            "ws": "^6.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
+          }
+        },
+        "q": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        },
+        "randomatic": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+          "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+          "requires": {
+            "is-number": "^4.0.0",
+            "kind-of": "^6.0.0",
+            "math-random": "^1.0.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "range-parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+          "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.0",
+            "http-errors": "1.7.2",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+              "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+              "dev": true
+            }
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+              "dev": true
+            }
+          }
+        },
+        "read-all-stream": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+          "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "read-chunk": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
+          "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "with-open-file": "^0.1.6"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+              "dev": true
+            },
+            "braces": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "dev": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+              "dev": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                  "dev": true
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+              "dev": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "dev": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            }
+          }
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+          "dev": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "reduce-flatten": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+          "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+          "dev": true
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+          "dev": true
+        },
+        "regenerate-unicode-properties": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+          "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        },
+        "regenerator-transform": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
+          "integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
+          "dev": true,
+          "requires": {
+            "private": "^0.1.6"
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+          "requires": {
+            "is-equal-shallow": "^0.1.3"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+          "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
+        },
+        "regexpu-core": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+          "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.0.2",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.1.0"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+          "dev": true,
+          "requires": {
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+          "dev": true,
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+          "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+          "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+              "dev": true
+            }
+          }
+        },
+        "relateurl": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+          "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+          "dev": true
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "repeat-element": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+          "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "dev": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+              "dev": true
+            }
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+        },
+        "require-package-name": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+          "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          }
+        },
+        "requirejs": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+          "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+          "dev": true
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+          "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-dir": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "dev": true,
+          "requires": {
+            "expand-tilde": "^1.2.2",
+            "global-modules": "^0.2.3"
+          }
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "rollup": {
+          "version": "1.16.7",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.16.7.tgz",
+          "integrity": "sha512-P3GVcbVSLLjHWFLKGerYRe3Q/yggRXmTZFx/4WZf4wzGwO6hAg5jyMAFMQKc0dts8rFID4BQngfoz6yQbI7iMQ==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "@types/node": "^12.0.10",
+            "acorn": "^6.1.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+              "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+              "dev": true
+            }
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "run-sequence": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
+          "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
+          "requires": {
+            "chalk": "*",
+            "gulp-util": "*"
+          }
+        },
+        "rx": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+          "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+          "dev": true
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+        },
+        "rx-lite-aggregates": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+          "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+          "requires": {
+            "rx-lite": "*"
+          }
+        },
+        "rxjs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+          "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "samsam": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+          "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+        },
+        "sauce-connect-launcher": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.7.tgz",
+          "integrity": "sha512-v07+QhFrxgz3seMFuRSonu3gW1s6DbcLQlFhjsRrmKUauzPbbudHdnn91WYgEwhoZVdPNzeZpAEJwcQyd9xnTA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "adm-zip": "~0.4.3",
+            "async": "^2.1.2",
+            "https-proxy-agent": "^2.2.1",
+            "lodash": "^4.16.6",
+            "rimraf": "^2.5.4"
+          }
+        },
+        "scoped-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
+          "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
+        },
+        "select-hose": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+          "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+          "dev": true
+        },
+        "selenium-standalone": {
+          "version": "6.16.0",
+          "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.16.0.tgz",
+          "integrity": "sha512-tl7HFH2FOxJD1is7Pzzsl0pY4vuePSdSWiJdPn+6ETBkpeJDiuzou8hBjvWYWpD+eIVcOrmy3L0R3GzkdHLzDw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "^2.6.2",
+            "commander": "^2.19.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.1.1",
+            "lodash": "^4.17.11",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "progress": "2.0.3",
+            "request": "2.88.0",
+            "tar-stream": "2.0.0",
+            "urijs": "^1.19.1",
+            "which": "^1.3.1",
+            "yauzl": "^2.10.0"
+          },
+          "dependencies": {
+            "bl": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+              "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.6",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.20.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+              "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true,
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+              "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "tar-stream": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.0.0.tgz",
+              "integrity": "sha512-n2vtsWshZOVr/SY4KtslPoUlyNh06I2SGgAOCZmquCEjlbV/LjY2CY80rDtdQRHFOYXNlgBDo6Fr3ww2CWPOtA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bl": "^2.2.0",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+          "dev": true,
+          "requires": {
+            "semver": "^5.0.3"
+          }
+        },
+        "send": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          },
+          "dependencies": {
+            "http-errors": {
+              "version": "1.6.3",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+              "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+              "dev": true,
+              "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "mime": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+              "dev": true
+            },
+            "setprototypeof": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+              "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+              "dev": true
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+              "dev": true
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+          "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+          "dev": true,
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.3",
+            "send": "0.17.1"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+              "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+              "dev": true
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true
+            },
+            "send": {
+              "version": "0.17.1",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+              "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+              "dev": true,
+              "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+              }
+            }
+          }
+        },
+        "server-destroy": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+          "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
+          "dev": true
+        },
+        "serviceworker-cache-polyfill": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+          "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves=",
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "set-value": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+          "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+              "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+          "dev": true
+        },
+        "shady-css-parser": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+          "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "shelljs": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+          "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "simple-swizzle": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+          "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.3.1"
+          },
+          "dependencies": {
+            "is-arrayish": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+              "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+              "dev": true
+            }
+          }
+        },
+        "sinon": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
+          "integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
+          "requires": {
+            "@sinonjs/formatio": "^2.0.0",
+            "diff": "^3.5.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.4.2",
+            "nise": "^1.3.3",
+            "supports-color": "^5.4.0",
+            "type-detect": "^4.0.8"
+          },
+          "dependencies": {
+            "lolex": {
+              "version": "2.7.5",
+              "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+              "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
+            }
+          }
+        },
+        "sinon-chai": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+          "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            }
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "dev": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+          "requires": {
+            "kind-of": "^3.2.0"
+          }
+        },
+        "socket.io": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
+          "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
+          "dev": true,
+          "requires": {
+            "debug": "~4.1.0",
+            "engine.io": "~3.3.1",
+            "has-binary2": "~1.0.2",
+            "socket.io-adapter": "~1.1.0",
+            "socket.io-client": "2.2.0",
+            "socket.io-parser": "~3.3.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "socket.io-adapter": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+          "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+          "dev": true
+        },
+        "socket.io-client": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+          "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "engine.io-client": "~3.3.1",
+            "has-binary2": "~1.0.2",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "~3.3.0",
+            "to-array": "0.1.4"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+              "dev": true
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "socket.io-parser": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+          "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "isarray": "2.0.1"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+              "dev": true
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "isarray": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+              "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+              "dev": true
+            }
+          }
+        },
+        "sort-keys": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+          "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+          "dev": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "sort-keys-length": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+          "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+          "dev": true,
+          "requires": {
+            "sort-keys": "^1.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+          "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.5.12",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            }
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "sparkles": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+          "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
+        },
+        "spawn-sync": {
+          "version": "1.0.15",
+          "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+          "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.4.7",
+            "os-shim": "^0.1.2"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+          "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+          "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+          "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+        },
+        "spdy": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+          "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "handle-thing": "^1.2.5",
+            "http-deceiver": "^1.2.7",
+            "safe-buffer": "^5.0.1",
+            "select-hose": "^2.0.0",
+            "spdy-transport": "^2.0.18"
+          }
+        },
+        "spdy-transport": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
+          "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+          "dev": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "detect-node": "^2.0.3",
+            "hpack.js": "^2.1.6",
+            "obuf": "^1.1.1",
+            "readable-stream": "^2.2.9",
+            "safe-buffer": "^5.0.1",
+            "wbuf": "^1.7.2"
+          }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "sshpk": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+          "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+          "dev": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "stable": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+          "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+          "dev": true
+        },
+        "stack-trace": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+          "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+          "dev": true
+        },
+        "stacky": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+          "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "lodash": "^3.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true
+        },
+        "stream": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+          "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+          "dev": true,
+          "requires": {
+            "emitter-component": "^1.1.1"
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+        },
+        "streamsearch": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+          "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+          "dev": true
+        },
+        "string-template": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+          "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-bom-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+          "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+          "requires": {
+            "first-chunk-stream": "^1.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "sw-precache": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
+          "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
+          "dev": true,
+          "requires": {
+            "dom-urls": "^1.1.0",
+            "es6-promise": "^4.0.5",
+            "glob": "^7.1.1",
+            "lodash.defaults": "^4.2.0",
+            "lodash.template": "^4.4.0",
+            "meow": "^3.7.0",
+            "mkdirp": "^0.5.1",
+            "pretty-bytes": "^4.0.2",
+            "sw-toolbox": "^3.4.0",
+            "update-notifier": "^2.3.0"
+          },
+          "dependencies": {
+            "update-notifier": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+              "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+              "dev": true,
+              "requires": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+              }
+            }
+          }
+        },
+        "sw-toolbox": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+          "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
+          "dev": true,
+          "requires": {
+            "path-to-regexp": "^1.0.1",
+            "serviceworker-cache-polyfill": "^4.0.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
+            "fast-deep-equal": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+              "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+              "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "table-layout": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
+          "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
+          "dev": true,
+          "requires": {
+            "array-back": "^2.0.0",
+            "deep-extend": "~0.6.0",
+            "lodash.padend": "^4.6.1",
+            "typical": "^2.6.1",
+            "wordwrapjs": "^3.0.0"
+          },
+          "dependencies": {
+            "array-back": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+              "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+              "dev": true,
+              "requires": {
+                "typical": "^2.6.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+              "dev": true
+            },
+            "typical": {
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+              "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+              "dev": true
+            }
+          }
+        },
+        "tar-fs": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+          "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pump": "^1.0.0",
+            "tar-stream": "^1.1.2"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+              "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+              "dev": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+          "dev": true,
+          "requires": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+          }
+        },
+        "temp": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+          "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+              "dev": true
+            }
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "execa": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+              "dev": true,
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+              "dev": true
+            }
+          }
+        },
+        "ternary-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+          "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
+          "dev": true,
+          "requires": {
+            "duplexify": "^3.5.0",
+            "fork-stream": "^0.0.4",
+            "merge-stream": "^1.0.0",
+            "through2": "^2.0.1"
+          }
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+          "dev": true
+        },
+        "text-hex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+          "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+          "dev": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+        },
+        "textextensions": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
+          "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA=="
+        },
+        "thenify": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+          "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+          "dev": true,
+          "requires": {
+            "any-promise": "^1.0.0"
+          }
+        },
+        "thenify-all": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+          "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+          "dev": true,
+          "requires": {
+            "thenify": ">= 3.1.0 < 4"
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        },
+        "through2-filter": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+          "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+          "requires": {
+            "through2": "~2.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "time-stamp": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+          "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+        },
+        "tmp": {
+          "version": "0.0.31",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+          "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "to-absolute-glob": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+          "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+          "requires": {
+            "extend-shallow": "^2.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "to-array": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+          "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+          "dev": true
+        },
+        "to-buffer": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            }
+          }
+        },
+        "toidentifier": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+          "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+              "dev": true
+            }
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+          "dev": true
+        },
+        "triple-beam": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+          "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
+          "dev": true
+        },
+        "tsc-then": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/tsc-then/-/tsc-then-1.1.0.tgz",
+          "integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
+          "requires": {
+            "@types/node": "^8.0.53",
+            "semver": "^5.4.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "8.10.50",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.50.tgz",
+              "integrity": "sha512-+ZbcUwJdaBgOZpwXeT0v+gHC/jQbEfzoc9s4d0rN0JIKeQbuTrT+A2n1aQY6LpZjrLXJT7avVUqiCecCJeeZxA=="
+            }
+          }
+        },
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+        },
+        "type-is": {
+          "version": "1.6.18",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+          "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+          "dev": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.24"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
+        "typical": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+          "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+          "dev": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.20",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+          "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "3.4.10",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+          "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
+          "requires": {
+            "commander": "~2.19.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.19.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+              "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        },
+        "unicode-canonical-property-names-ecmascript": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+          "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+          "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+          "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+          "dev": true,
+          "requires": {
+            "unicode-canonical-property-names-ecmascript": "^1.0.4",
+            "unicode-property-aliases-ecmascript": "^1.0.4"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+          "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+          "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+          "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+          "dev": true
+        },
+        "union-value": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+          "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^2.0.1"
+          }
+        },
+        "unique-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+          "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+          "requires": {
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "through2-filter": "^3.0.0"
+          },
+          "dependencies": {
+            "through2-filter": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+              "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+              "requires": {
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
+              }
+            }
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^1.0.0"
+          }
+        },
+        "universal-user-agent": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
+          "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
+          "dev": true,
+          "requires": {
+            "os-name": "^3.0.0"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+          "dev": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+          "dev": true
+        },
+        "update-notifier": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+          "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+          "dev": true,
+          "requires": {
+            "boxen": "^0.6.0",
+            "chalk": "^1.0.0",
+            "configstore": "^2.0.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^2.0.0",
+            "lazy-req": "^1.1.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-align": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+              "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.1"
+              }
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "boxen": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+              "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+              "dev": true,
+              "requires": {
+                "ansi-align": "^1.1.0",
+                "camelcase": "^2.1.0",
+                "chalk": "^1.1.1",
+                "cli-boxes": "^1.0.0",
+                "filled-array": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "repeating": "^2.0.0",
+                "string-width": "^1.0.1",
+                "widest-line": "^1.0.0"
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "configstore": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+              "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+              "dev": true,
+              "requires": {
+                "dot-prop": "^3.0.0",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.1",
+                "os-tmpdir": "^1.0.0",
+                "osenv": "^0.1.0",
+                "uuid": "^2.0.1",
+                "write-file-atomic": "^1.1.2",
+                "xdg-basedir": "^2.0.0"
+              }
+            },
+            "dot-prop": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+              "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+              "dev": true,
+              "requires": {
+                "is-obj": "^1.0.0"
+              }
+            },
+            "got": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+              "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+              "dev": true,
+              "requires": {
+                "create-error-class": "^3.0.1",
+                "duplexer2": "^0.1.4",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "node-status-codes": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "parse-json": "^2.1.0",
+                "pinkie-promise": "^2.0.0",
+                "read-all-stream": "^3.0.0",
+                "readable-stream": "^2.0.5",
+                "timed-out": "^3.0.0",
+                "unzip-response": "^1.0.2",
+                "url-parse-lax": "^1.0.0"
+              }
+            },
+            "latest-version": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+              "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+              "dev": true,
+              "requires": {
+                "package-json": "^2.0.0"
+              }
+            },
+            "package-json": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+              "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+              "dev": true,
+              "requires": {
+                "got": "^5.0.0",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            },
+            "timed-out": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+              "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+              "dev": true
+            },
+            "unzip-response": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+              "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+              "dev": true
+            },
+            "uuid": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+              "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+              "dev": true
+            },
+            "widest-line": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+              "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.1"
+              }
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+              "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
+              }
+            },
+            "xdg-basedir": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+              "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+              "dev": true,
+              "requires": {
+                "os-homedir": "^1.0.0"
+              }
+            }
+          }
+        },
+        "upper-case": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+          "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+          "dev": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "urijs": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+          "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==",
+          "dev": true
+        },
+        "urix": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "url-template": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+          "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+          "dev": true
+        },
+        "url-to-options": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+          "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+        },
+        "use": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+          "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
+        },
+        "vali-date": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+          "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+        },
+        "validate-element-name": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/validate-element-name/-/validate-element-name-2.1.1.tgz",
+          "integrity": "sha1-j/dffaafc+fFEFiDYhMFCLesZE4=",
+          "dev": true,
+          "requires": {
+            "is-potential-custom-element-name": "^1.0.0",
+            "log-symbols": "^1.0.0",
+            "meow": "^3.7.0"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "vargs": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+          "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
+          "dev": true
+        },
+        "vary": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+          "dev": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+            }
+          }
+        },
+        "vinyl-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+          "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.3.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^2.0.0",
+            "vinyl": "^1.1.0"
+          },
+          "dependencies": {
+            "first-chunk-stream": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+              "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+              "requires": {
+                "readable-stream": "^2.0.2"
+              }
+            },
+            "strip-bom-stream": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+              "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+              "requires": {
+                "first-chunk-stream": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+          "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+          "requires": {
+            "duplexify": "^3.2.0",
+            "glob-stream": "^5.3.2",
+            "graceful-fs": "^4.0.0",
+            "gulp-sourcemaps": "1.6.0",
+            "is-valid-glob": "^0.3.0",
+            "lazystream": "^1.0.0",
+            "lodash.isequal": "^4.0.0",
+            "merge-stream": "^1.0.0",
+            "mkdirp": "^0.5.0",
+            "object-assign": "^4.0.0",
+            "readable-stream": "^2.0.4",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^1.0.0",
+            "through2": "^2.0.0",
+            "through2-filter": "^2.0.0",
+            "vali-date": "^1.0.0",
+            "vinyl": "^1.0.0"
+          }
+        },
+        "vinyl-fs-fake": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vinyl-fs-fake/-/vinyl-fs-fake-1.1.1.tgz",
+          "integrity": "sha512-FY1KYQwp4yRt2695GqppK9viJTysuH6n6ns3t94l3wYFJlyf7YHtqCdNZGrMrpC1yLZZlueTioiOsL/6lFHykw==",
+          "requires": {
+            "through2": "^0.6.3",
+            "vinyl": "^0.4.6",
+            "vinyl-fs": "^2.4.4"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            },
+            "through2": {
+              "version": "0.6.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "requires": {
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+              "requires": {
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
+              }
+            }
+          }
+        },
+        "vlq": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+          "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+          "dev": true
+        },
+        "vscode-uri": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+          "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==",
+          "dev": true
+        },
+        "walkdir": {
+          "version": "0.0.11",
+          "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+          "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+        },
+        "wbuf": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+          "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+          "dev": true,
+          "requires": {
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "wct-local": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/wct-local/-/wct-local-2.1.5.tgz",
+          "integrity": "sha512-eqoZhjGy4Xq2tY0uB46Grkw/ztq+/rC0ImbYKl62unFHXtOgal+kkvnxR3SLRFNM8ty9+ItgycPeH0IpTqVL+w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/express": "^4.0.30",
+            "@types/freeport": "^1.0.19",
+            "@types/launchpad": "^0.6.0",
+            "@types/which": "^1.3.1",
+            "chalk": "^2.3.0",
+            "cleankill": "^2.0.0",
+            "freeport": "^1.0.4",
+            "launchpad": "^0.7.0",
+            "selenium-standalone": "^6.7.0",
+            "which": "^1.0.8"
+          }
+        },
+        "wct-sauce": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wct-sauce/-/wct-sauce-2.1.0.tgz",
+          "integrity": "sha512-c3R4PJcbpS7Gxv2vZ4HDAqpXV6cT9peslAWMU7hHH9PMhKDPbn8RNa6E4DVL0tOmZznB+3cRmtZ6+vJ/aDwu1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "cleankill": "^2.0.0",
+            "lodash": "^4.17.10",
+            "request": "^2.85.0",
+            "sauce-connect-launcher": "^1.0.0",
+            "temp": "^0.8.1",
+            "uuid": "^3.2.1"
+          }
+        },
+        "wd": {
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/wd/-/wd-1.11.2.tgz",
+          "integrity": "sha512-zXJY9ARjQQYN2LatLTRcW39EYzIVqKNhGpp4XWJmRgHBioG4FoenIOsoVbaO8lnFGgv31V99kAy5hB4eWGIwzA==",
+          "dev": true,
+          "requires": {
+            "archiver": "2.1.1",
+            "async": "2.0.1",
+            "lodash": "4.17.11",
+            "mkdirp": "^0.5.1",
+            "q": "1.4.1",
+            "request": "2.88.0",
+            "vargs": "0.1.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+              "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+              "dev": true,
+              "requires": {
+                "lodash": "^4.8.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.11",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+              "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+              "dev": true
+            },
+            "q": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+              "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+              "dev": true
+            }
+          }
+        },
+        "web-component-tester": {
+          "version": "6.9.2",
+          "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.9.2.tgz",
+          "integrity": "sha512-s2kB/+IE8XWcnxY1fqSpqTiiHEGHWgUWariAbiRlxmAvWSuvaCVNALHYebsZrLCNCLHKcJR8/sGv/bw0MWMvjw==",
+          "dev": true,
+          "requires": {
+            "@polymer/sinonjs": "^1.14.1",
+            "@polymer/test-fixture": "^0.0.3",
+            "@webcomponents/webcomponentsjs": "^1.0.7",
+            "accessibility-developer-tools": "^2.12.0",
+            "async": "^2.4.1",
+            "body-parser": "^1.17.2",
+            "bower-config": "^1.4.0",
+            "chalk": "^1.1.3",
+            "cleankill": "^2.0.0",
+            "express": "^4.15.3",
+            "findup-sync": "^2.0.0",
+            "glob": "^7.1.2",
+            "lodash": "^3.10.1",
+            "multer": "^1.3.0",
+            "nomnom": "^1.8.1",
+            "polyserve": "^0.27.13",
+            "resolve": "^1.5.0",
+            "semver": "^5.3.0",
+            "send": "^0.16.1",
+            "server-destroy": "^1.0.1",
+            "sinon": "^2.3.5",
+            "sinon-chai": "^2.10.0",
+            "socket.io": "^2.0.3",
+            "stacky": "^1.3.1",
+            "update-notifier": "^2.2.0",
+            "wct-local": "^2.1.1",
+            "wct-sauce": "^2.0.2",
+            "wd": "^1.2.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "arr-diff": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+              "dev": true
+            },
+            "braces": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "dev": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "detect-file": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+              "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+              "dev": true
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+              "dev": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                  "dev": true
+                }
+              }
+            },
+            "expand-tilde": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+              "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+              "dev": true,
+              "requires": {
+                "homedir-polyfill": "^1.0.1"
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+              "dev": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "findup-sync": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+              "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+              "dev": true,
+              "requires": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
+              }
+            },
+            "global-modules": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+              "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+              "dev": true,
+              "requires": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+              }
+            },
+            "global-prefix": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+              "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+              "dev": true,
+              "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+              "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+              "dev": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "dev": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            },
+            "resolve-dir": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+              "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+              "dev": true,
+              "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+              }
+            },
+            "sinon": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+              "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+              "dev": true,
+              "requires": {
+                "diff": "^3.1.0",
+                "formatio": "1.2.0",
+                "lolex": "^1.6.0",
+                "native-promise-only": "^0.8.1",
+                "path-to-regexp": "^1.7.0",
+                "samsam": "^1.1.3",
+                "text-encoding": "0.6.4",
+                "type-detect": "^4.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            },
+            "update-notifier": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+              "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                  "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "color-convert": "^1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.4.2",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                  "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ansi-styles": "^3.2.1",
+                    "escape-string-regexp": "^1.0.5",
+                    "supports-color": "^5.3.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "widest-line": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "windows-release": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+          "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0"
+          }
+        },
+        "winston": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+          "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.1",
+            "diagnostics": "^1.1.1",
+            "is-stream": "^1.1.0",
+            "logform": "^2.1.1",
+            "one-time": "0.0.4",
+            "readable-stream": "^3.1.1",
+            "stack-trace": "0.0.x",
+            "triple-beam": "^1.3.0",
+            "winston-transport": "^4.3.0"
+          },
+          "dependencies": {
+            "logform": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+              "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+              "dev": true,
+              "requires": {
+                "colors": "^1.2.1",
+                "fast-safe-stringify": "^2.0.4",
+                "fecha": "^2.3.3",
+                "ms": "^2.1.1",
+                "triple-beam": "^1.3.0"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+              "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
+          }
+        },
+        "winston-transport": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+          "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.6",
+            "triple-beam": "^1.2.0"
+          }
+        },
+        "with-open-file": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.6.tgz",
+          "integrity": "sha512-SQS05JekbtwQSgCYlBsZn/+m2gpn4zWsqpCYIrCHva0+ojXcnmUEPsBN6Ipoz3vmY/81k5PvYEWSxER2g4BTqA==",
+          "dev": true,
+          "requires": {
+            "p-finally": "^1.0.0",
+            "p-try": "^2.1.0",
+            "pify": "^4.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+              "dev": true
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        },
+        "wordwrapjs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+          "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+          "dev": true,
+          "requires": {
+            "reduce-flatten": "^1.0.1",
+            "typical": "^2.6.1"
+          },
+          "dependencies": {
+            "typical": {
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+              "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+              "dev": true
+            }
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+          "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ws": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+          "dev": true
+        },
+        "xmlbuilder": {
+          "version": "8.2.2",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+          "dev": true,
+          "optional": true
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+          "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+          "dev": true,
+          "optional": true
+        },
+        "xmlhttprequest-ssl": {
+          "version": "1.5.5",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+          "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+              "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+              "requires": {
+                "pify": "^2.0.0"
+              }
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "requires": {
+            "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+            }
+          }
+        },
+        "yauzl": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+          "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.1.0"
+          }
+        },
+        "yeast": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+          "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+          "dev": true
+        },
+        "yeoman-assert": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-2.2.3.tgz",
+          "integrity": "sha1-pWgqg2MsUKwO6EFzpaEP1vMgZHQ="
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+          "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "diff": {
+              "version": "2.2.3",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+              "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+              "dev": true
+            },
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globby": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+              "dev": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^6.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-3.2.0.tgz",
+          "integrity": "sha512-iR/qb2je3GdXtSfxgvOXxUW0Cp8+C6LaZaNlK2BAICzFNzwHtM10t/QBwz5Ea9nk6xVDQNj4Q889TjCXGuIv8w==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "chalk": "^2.3.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^6.0.5",
+            "dargs": "^6.0.0",
+            "dateformat": "^3.0.3",
+            "debug": "^4.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^3.0.0",
+            "github-username": "^4.0.0",
+            "istextorbinary": "^2.2.1",
+            "lodash": "^4.17.10",
+            "make-dir": "^1.1.0",
+            "mem-fs-editor": "^5.0.0",
+            "minimist": "^1.2.0",
+            "pretty-bytes": "^5.1.0",
+            "read-chunk": "^3.0.0",
+            "read-pkg-up": "^4.0.0",
+            "rimraf": "^2.6.2",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.8.0",
+            "text-table": "^0.2.0",
+            "through2": "^3.0.0",
+            "yeoman-environment": "^2.0.5"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+              "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+              "dev": true,
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "external-editor": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+              "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+              "dev": true,
+              "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+              }
+            },
+            "figures": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+              "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+              "dev": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "inquirer": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
+              "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+              "dev": true,
+              "requires": {
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.11",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.4.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^5.1.0",
+                "through": "^2.3.6"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                  "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                  "dev": true
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                  "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
+                  }
+                }
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "log-symbols": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+              "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.0.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+              "dev": true
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+              "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+              "dev": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+              "dev": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+              "dev": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            },
+            "pretty-bytes": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
+              "integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w==",
+              "dev": true
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+              "dev": true,
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+              "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+              "dev": true,
+              "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+              "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+              "dev": true,
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+              "dev": true
+            },
+            "through2": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+              "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2 || 3"
+              }
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "untildify": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+              "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
+              "dev": true
+            },
+            "yeoman-environment": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.4.0.tgz",
+              "integrity": "sha512-SsvoL0RNAFIX69eFxkUhwKUN2hG1UwUjxrcP+T2ytwdhqC/kHdnFOH2SXdtSN1Ju4aO4xuimmzfRoheYY88RuA==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "diff": "^3.5.0",
+                "escape-string-regexp": "^1.0.2",
+                "globby": "^8.0.1",
+                "grouped-queue": "^0.3.3",
+                "inquirer": "^6.0.0",
+                "is-scoped": "^1.0.0",
+                "lodash": "^4.17.10",
+                "log-symbols": "^2.2.0",
+                "mem-fs": "^1.1.0",
+                "strip-ansi": "^4.0.0",
+                "text-table": "^0.2.0",
+                "untildify": "^3.0.3"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.2.6",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                  "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "^2.1.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "yeoman-test": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.9.1.tgz",
+          "integrity": "sha512-aWB8CglmjBfXd+U5g5Cm1b8KVW0uotjo521IgkepvhNXiAX/YswHYGVnbEFb0m9ZdXztELuNJn2UtuwgFZIw6Q==",
+          "requires": {
+            "inquirer": "^5.2.0",
+            "lodash": "^4.17.10",
+            "mkdirp": "^0.5.1",
+            "pinkie-promise": "^2.0.1",
+            "rimraf": "^2.4.4",
+            "sinon": "^5.0.7",
+            "yeoman-environment": "^2.3.0",
+            "yeoman-generator": "^2.0.5"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+              "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
+            "chardet": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+              "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "clone-stats": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+              "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+            },
+            "dargs": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+              "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
+            },
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+            },
+            "external-editor": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+              "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+              "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+              }
+            },
+            "figures": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+              "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "inquirer": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+              "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.1.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^5.5.2",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "log-symbols": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+              "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+              "requires": {
+                "chalk": "^2.0.1"
+              }
+            },
+            "mem-fs-editor": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
+              "integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
+              "requires": {
+                "commondir": "^1.0.1",
+                "deep-extend": "^0.6.0",
+                "ejs": "^2.5.9",
+                "glob": "^7.0.3",
+                "globby": "^7.1.1",
+                "isbinaryfile": "^3.0.2",
+                "mkdirp": "^0.5.0",
+                "multimatch": "^2.0.0",
+                "rimraf": "^2.2.8",
+                "through2": "^2.0.0",
+                "vinyl": "^2.0.1"
+              },
+              "dependencies": {
+                "globby": {
+                  "version": "7.1.1",
+                  "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+                  "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+                  "requires": {
+                    "array-union": "^1.0.1",
+                    "dir-glob": "^2.0.0",
+                    "glob": "^7.1.2",
+                    "ignore": "^3.3.5",
+                    "pify": "^3.0.0",
+                    "slash": "^1.0.0"
+                  }
+                }
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+              "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+              "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            },
+            "read-chunk": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
+              "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+              "requires": {
+                "pify": "^3.0.0",
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+              "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "replace-ext": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+              "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+              "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "rxjs": {
+              "version": "5.5.12",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+              "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+              "requires": {
+                "symbol-observable": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "untildify": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+              "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+            },
+            "vinyl": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+              "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+              "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+              }
+            },
+            "yeoman-environment": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.4.0.tgz",
+              "integrity": "sha512-SsvoL0RNAFIX69eFxkUhwKUN2hG1UwUjxrcP+T2ytwdhqC/kHdnFOH2SXdtSN1Ju4aO4xuimmzfRoheYY88RuA==",
+              "requires": {
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "diff": "^3.5.0",
+                "escape-string-regexp": "^1.0.2",
+                "globby": "^8.0.1",
+                "grouped-queue": "^0.3.3",
+                "inquirer": "^6.0.0",
+                "is-scoped": "^1.0.0",
+                "lodash": "^4.17.10",
+                "log-symbols": "^2.2.0",
+                "mem-fs": "^1.1.0",
+                "strip-ansi": "^4.0.0",
+                "text-table": "^0.2.0",
+                "untildify": "^3.0.3"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                  "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                },
+                "chardet": {
+                  "version": "0.7.0",
+                  "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+                  "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+                },
+                "external-editor": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+                  "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+                  "requires": {
+                    "chardet": "^0.7.0",
+                    "iconv-lite": "^0.4.24",
+                    "tmp": "^0.0.33"
+                  }
+                },
+                "inquirer": {
+                  "version": "6.4.1",
+                  "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
+                  "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+                  "requires": {
+                    "ansi-escapes": "^3.2.0",
+                    "chalk": "^2.4.2",
+                    "cli-cursor": "^2.1.0",
+                    "cli-width": "^2.0.0",
+                    "external-editor": "^3.0.3",
+                    "figures": "^2.0.0",
+                    "lodash": "^4.17.11",
+                    "mute-stream": "0.0.7",
+                    "run-async": "^2.2.0",
+                    "rxjs": "^6.4.0",
+                    "string-width": "^2.1.0",
+                    "strip-ansi": "^5.1.0",
+                    "through": "^2.3.6"
+                  },
+                  "dependencies": {
+                    "strip-ansi": {
+                      "version": "5.2.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                      "requires": {
+                        "ansi-regex": "^4.1.0"
+                      }
+                    }
+                  }
+                },
+                "rxjs": {
+                  "version": "6.5.2",
+                  "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+                  "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+                  "requires": {
+                    "tslib": "^1.9.0"
+                  }
+                }
+              }
+            },
+            "yeoman-generator": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+              "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
+              "requires": {
+                "async": "^2.6.0",
+                "chalk": "^2.3.0",
+                "cli-table": "^0.3.1",
+                "cross-spawn": "^6.0.5",
+                "dargs": "^5.1.0",
+                "dateformat": "^3.0.3",
+                "debug": "^3.1.0",
+                "detect-conflict": "^1.0.0",
+                "error": "^7.0.2",
+                "find-up": "^2.1.0",
+                "github-username": "^4.0.0",
+                "istextorbinary": "^2.2.1",
+                "lodash": "^4.17.10",
+                "make-dir": "^1.1.0",
+                "mem-fs-editor": "^4.0.0",
+                "minimist": "^1.2.0",
+                "pretty-bytes": "^4.0.2",
+                "read-chunk": "^2.1.0",
+                "read-pkg-up": "^3.0.0",
+                "rimraf": "^2.6.2",
+                "run-async": "^2.0.0",
+                "shelljs": "^0.8.0",
+                "text-table": "^0.2.0",
+                "through2": "^2.0.0",
+                "yeoman-environment": "^2.0.5"
+              }
+            }
+          }
+        },
+        "zip-stream": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+          "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^1.3.0",
+            "compress-commons": "^1.2.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0"
+          }
+        }
+      }
+    },
+    "portfinder": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      }
     },
     "propagating-hammerjs": {
       "version": "1.4.7",
@@ -1462,10 +16222,149 @@
         "hammerjs": "^2.0.8"
       }
     },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      }
+    },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
+    },
+    "stacky": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+      "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "lodash": "^3.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
+    "url-join": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "dev": true
+    },
+    "util": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
     },
     "visjs-network": {
       "version": "4.24.11",
@@ -1480,10 +16379,70 @@
         "timsort": "^0.3.0"
       }
     },
+    "wct-browser-legacy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
+      "integrity": "sha512-23rbZwBh/DxWU36htJN9lsyBq3NxgVbuyMUq7fgFP6ZVTel+uFWO6LPXPoZQ6VyvXvlUYLE5PxY+ZdJ88a4COw==",
+      "dev": true,
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@polymer/sinonjs": "^1.14.1",
+        "@polymer/test-fixture": "^3.0.0-pre.1",
+        "@webcomponents/webcomponentsjs": "^2.0.0",
+        "accessibility-developer-tools": "^2.12.0",
+        "async": "^1.5.2",
+        "chai": "^3.5.0",
+        "lodash": "^3.10.1",
+        "mocha": "^3.4.2",
+        "sinon": "^1.17.1",
+        "sinon-chai": "^2.10.0",
+        "stacky": "^1.3.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
+      }
+    },
+    "wct-mocha": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wct-mocha/-/wct-mocha-1.1.0.tgz",
+      "integrity": "sha512-Wq7xtXFtsCs4bZxjjgRp1PKV3sx7NrSl1JqEVI4zF0/yavlYa9hRMO/+73u1ZScnHc5kIKNPT3KBsoCaQI3+MQ==",
+      "dev": true
+    },
     "web-animations-js": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/web-animations-js/-/web-animations-js-2.3.2.tgz",
       "integrity": "sha512-TOMFWtQdxzjWp8qx4DAraTWTsdhxVSiWa6NkPFSaPtZ1diKUxTn4yTix73A1euG1WbSOMMPcY51cnjTIHrGtDA=="
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "start:dev": "polymer serve --proxy-target http://localhost:9000/api --proxy-path api",
     "build": "polymer build",
     "lint": "polymer lint",
-    "test": "polymer test",
-    "test:integration": "polymer build # test that psk builds without error with the CLI"
+    "test": "polymer test"
   },
   "dependencies": {
     "@polymer/app-layout": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,10 @@
     "web-animations-js": "^2.3.1"
   },
   "devDependencies": {
-    "http-server": "0.12.3"
+    "http-server": "0.12.3",
+    "polymer-cli": "^1.9.11",
+    "wct-browser-legacy": "^1.0.2",
+    "wct-mocha": "^1.1.0"
   },
   "engines": {
     "node": ">=8.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "serve": "hs -c0 ./build/dev/ -P http://localhost:9000",
     "start": "polymer serve",
+    "start:dev": "polymer serve --proxy-target http://localhost:9000/api --proxy-path api",
     "build": "polymer build",
     "lint": "polymer lint",
     "test": "polymer test",

--- a/polymer.json
+++ b/polymer.json
@@ -22,7 +22,6 @@
     {
       "name": "prod",
       "bundle": true,
-      "addPushManifest": true,
       "js": {
         "minify": true
       },

--- a/polymer.json
+++ b/polymer.json
@@ -28,6 +28,10 @@
   "lint": {
     "rules": [
       "polymer-3"
+    ],
+    "ignoreWarnings": [
+      "could-not-load",
+      "not-loadable"
     ]
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -20,7 +20,18 @@
   ],
   "builds": [
     {
-      "name" : "dev"
+      "name": "prod",
+      "bundle": true,
+      "addPushManifest": true,
+      "js": {
+        "minify": true
+      },
+      "css": {
+        "minify": true
+      },
+      "html": {
+        "minify": true
+      }
     }
   ],
   "moduleResolution": "node",

--- a/src/my-app.js
+++ b/src/my-app.js
@@ -271,6 +271,10 @@ class MyApp extends mixinBehaviors([AppLocalizeBehavior], PolymerElement) {
         this.addEventListener('push-crumb', this._onPushCrumb);
     }
 
+    _feedbackChanged() {
+        console.log(arguments);
+    }
+
     _getDrawer(){
         var dL = this.shadowRoot.querySelector('#drawerLayout');
         if(dL){

--- a/test/index.html
+++ b/test/index.html
@@ -12,12 +12,7 @@
   </head>
   <body>
     <script>
-      WCT.loadSuites([
-        // Load 'my-view1.html' test suite, using native shadow dom
-        'my-view1.html?dom=shadow',
-        // Load 'my-view1.html' test suite, using shadydom
-        'my-view1.html?wc-shadydom=true',
-      ]);
+      WCT.loadSuites([]);
     </script>
   </body>
 </html>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,15 @@
+{
+  "testTimeout": 10000,
+  "plugins": {
+    "local": {
+      "browsers": ["chrome"],
+      "browserOptions": {
+        "chrome": [
+          "headless",
+          "disable-gpu",
+          "no-sandbox"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Merging this will adds the following:
- makes the package independent of operating system, any script command will work only after runing `npm install` because of adding missing packages under `devDependencies`(this is explained here [0]) in `package.json`.
- `npm run build` (now with prod build, minify for html, css and js)
- `npm run lint`
- `npm test` (only chrome is being checked)
- `npm start` (default start on 8081 using `polymer serve` command)
- `npm run start:dev` (uses the `polymer serve` command with some arguments and proxies everything that's under /api to the mock, if it's not under /api it won't work and you need to use the `npm run serve` command, due to polymer cli contraints)

[0] - https://stackoverflow.com/a/48826003

Signed-off-by: Sirbu Nicolae-Cezar <sirbunicolaecezar@gmail.com>