### PR TITLE
fixed egeria-asset-tools not showing up when clicking on a node

### DIFF
--- a/new/asset-lineage/egeria-asset-lineage.container.js
+++ b/new/asset-lineage/egeria-asset-lineage.container.js
@@ -431,6 +431,7 @@ class EgeriaAssetLineage extends mixinBehaviors([EgeriaItemUtilsBehavior, RoleCo
 
               <egeria-asset-tools type="[[ selectedNode.group ]]"
                           guid="[[ selectedNode.id ]]"
+                          components="[[ components ]]
                           on-button-click="_closeDialog"
                           style="display: inline-flex"></egeria-asset-tools>
 


### PR DESCRIPTION
Signed-off-by: marius-patrascu <marius-florin.patrascu@ing.com>