### PR TITLE
odpi/egeria#5686 fully qualify base image name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Egeria project
 
-FROM nginx:latest
+FROM docker.io/library/nginx:latest
 
 ARG version=1.4.0
 ARG VCS_REF=unknown


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Fully qualify image names for Docker as per https://github.com/odpi/egeria/issues/5670